### PR TITLE
Added Span Count method for better performance

### DIFF
--- a/strings-csharp/CountingCharOccurences/CountingCharOccurences/CountChars.cs
+++ b/strings-csharp/CountingCharOccurences/CountingCharOccurences/CountChars.cs
@@ -1,6 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using System.Text.RegularExpressions;
+using CommunityToolkit.HighPerformance;
 
 namespace CountingCharOccurences
 {
@@ -130,6 +131,13 @@ namespace CountingCharOccurences
         public int CountCharsUsingRegex(string source, char toFind)
         {
             return new Regex(Regex.Escape(toFind.ToString())).Matches(source).Count;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(GenerateStringWithCharArgs))]
+        public int CountCharsUsingSpanCount(string source, char toFind)
+        {
+            return source.AsSpan().Count(toFind);
         }
     }
 }

--- a/strings-csharp/CountingCharOccurences/CountingCharOccurences/CountingCharOccurences.csproj
+++ b/strings-csharp/CountingCharOccurences/CountingCharOccurences/CountingCharOccurences.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="CommunityToolkit.HighPerformance" />
+  </ItemGroup>
 </Project>

--- a/strings-csharp/CountingCharOccurences/Test/Test.cs
+++ b/strings-csharp/CountingCharOccurences/Test/Test.cs
@@ -115,5 +115,16 @@ namespace Test
 
             Assert.Equal(2, actual);
         }
+
+        [Fact]
+        public void WhenSearchCharUsingSpanCountThenReturnNumberOfOccurences()
+        {
+            string main = "Mary Had A Little Lamb";
+            char toFind = 'L';
+
+            int actual = _countChars.CountCharsUsingSpanCount(main, toFind);
+
+            Assert.Equal(2, actual);
+        }
     }
 }

--- a/strings-csharp/CountingCharOccurences/Test/Test.csproj
+++ b/strings-csharp/CountingCharOccurences/Test/Test.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
The [SpanExtensions.Count](https://learn.microsoft.com/en-us/dotnet/api/microsoft.toolkit.highperformance.extensions.spanextensions.count?view=win-comm-toolkit-dotnet-6.1) method from the [CommunityToolkit.HighPerformance](https://www.nuget.org/packages/CommunityToolkit.HighPerformance/) nuget package is more than 3 times faster than the fastest method of counting characters in a string that this repo demonstrates.