### PR TITLE
CM-349: How to Use SQL LIKE operator in C# LINQ

### DIFF
--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator.sln
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LINQLikeOperator", "LINQLikeOperator\LINQLikeOperator.csproj", "{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LINQLikeOperator", "LINQLikeOperator\LINQLikeOperator.csproj", "{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LINQLikeOperatorTests", "LINQLikeOperatorTests\LINQLikeOperatorTests.csproj", "{5D9E5020-F394-482C-BFA9-045D9E98608A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D9E5020-F394-482C-BFA9-045D9E98608A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D9E5020-F394-482C-BFA9-045D9E98608A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D9E5020-F394-482C-BFA9-045D9E98608A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D9E5020-F394-482C-BFA9-045D9E98608A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator.sln
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LINQLikeOperator", "LINQLikeOperator\LINQLikeOperator.csproj", "{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41EC1B37-771D-4106-BE8A-C42FFFEA54B9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A45D776B-85B6-43D3-B448-D414B310E92E}
+	EndGlobalSection
+EndGlobal

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator/BlogDbContext.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator/BlogDbContext.cs
@@ -1,0 +1,10 @@
+﻿namespace LINQLikeOperator;
+
+public class BlogDbContext : DbContext
+{
+    public BlogDbContext(DbContextOptions<BlogDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Article> Articles { get; set; }
+}

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator/LINQLikeOperator.csproj
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator/LINQLikeOperator.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Data\Database1.mdf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\Database1_log.ldf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator/LINQLikeOperator.csproj
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator/LINQLikeOperator.csproj
@@ -11,13 +11,4 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Data\Database1.mdf">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Data\Database1_log.ldf">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator/Models/Article.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator/Models/Article.cs
@@ -1,0 +1,8 @@
+﻿namespace LINQLikeOperator.Models;
+
+public class Article
+{
+    [Key]
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+}

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator/Program.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator/Program.cs
@@ -1,11 +1,16 @@
 ﻿string sqlConnectionString = $@"Data Source=(LocalDB)\MSSQLLocalDB;Database=BlogDb ;Integrated Security=True";
-DbContextOptions<BlogDbContext> contextOption = new DbContextOptionsBuilder<BlogDbContext>()
+
+var contextOption = new DbContextOptionsBuilder<BlogDbContext>()
     .UseSqlServer(sqlConnectionString)
     .LogTo(Console.WriteLine, new[] { DbLoggerCategory.Database.Name }, LogLevel.Information)
     .Options;
-BlogDbContext blogDbContext = new BlogDbContext(contextOption);
 
+var blogDbContext = new BlogDbContext(contextOption);
 blogDbContext.Database.EnsureCreated();
+
 List<Article> articles = blogDbContext.Articles.Where(x => x.Title.Contains("n")).ToList();
 int articleCounts = blogDbContext.Articles.Count(x => x.Title.Contains("n"));
 Article? firstArticle = blogDbContext.Articles.FirstOrDefault(x => x.Title.Contains("n"));
+
+articles = blogDbContext.Articles.Where(x => x.Title.StartsWith("n")).ToList();
+articles = blogDbContext.Articles.Where(x => x.Title.EndsWith("n")).ToList();

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator/Program.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator/Program.cs
@@ -1,4 +1,4 @@
-﻿string sqlConnectionString = $@"Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename={AppDomain.CurrentDomain.BaseDirectory}Data\Database1.mdf;Integrated Security=True";
+﻿string sqlConnectionString = $@"Data Source=(LocalDB)\MSSQLLocalDB;Database=BlogDb ;Integrated Security=True";
 DbContextOptions<BlogDbContext> contextOption = new DbContextOptionsBuilder<BlogDbContext>()
     .UseSqlServer(sqlConnectionString)
     .LogTo(Console.WriteLine, new[] { DbLoggerCategory.Database.Name }, LogLevel.Information)

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator/Program.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator/Program.cs
@@ -1,0 +1,11 @@
+﻿string sqlConnectionString = $@"Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename={AppDomain.CurrentDomain.BaseDirectory}Data\Database1.mdf;Integrated Security=True";
+DbContextOptions<BlogDbContext> contextOption = new DbContextOptionsBuilder<BlogDbContext>()
+    .UseSqlServer(sqlConnectionString)
+    .LogTo(Console.WriteLine, new[] { DbLoggerCategory.Database.Name }, LogLevel.Information)
+    .Options;
+BlogDbContext blogDbContext = new BlogDbContext(contextOption);
+
+blogDbContext.Database.EnsureCreated();
+List<Article> articles = blogDbContext.Articles.Where(x => x.Title.Contains("n")).ToList();
+int articleCounts = blogDbContext.Articles.Count(x => x.Title.Contains("n"));
+Article? firstArticle = blogDbContext.Articles.FirstOrDefault(x => x.Title.Contains("n"));

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperator/Usings.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperator/Usings.cs
@@ -1,0 +1,5 @@
+﻿global using LINQLikeOperator;
+global using LINQLikeOperator.Models;
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.Extensions.Logging;
+global using System.ComponentModel.DataAnnotations;

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/DatabaseFixture.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/DatabaseFixture.cs
@@ -2,11 +2,11 @@
 
 public class DatabaseFixture : IDisposable
 {
-    public string startsWithN = "nop";
-    public string containsN = "mnp";
-    public string endsWithN = "lmn";
-    public string notContainsN = "abc";
-    public BlogDbContext? blogDbContext;
+    internal string startsWithN = "nop";
+    internal string containsN = "mnp";
+    internal string endsWithN = "lmn";
+    internal string notContainsN = "abc";
+    internal BlogDbContext? blogDbContext;
 
     public DatabaseFixture()
     {

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/DatabaseFixture.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/DatabaseFixture.cs
@@ -1,0 +1,31 @@
+﻿namespace LINQLikeOperatorTests;
+
+public class DatabaseFixture : IDisposable
+{
+    public string startsWithN = "nop";
+    public string containsN = "mnp";
+    public string endsWithN = "lmn";
+    public string notIncludeN = "abc";
+    public BlogDbContext? blogDbContext;
+
+    public DatabaseFixture()
+    {
+        DbContextOptions<BlogDbContext> contextOption = new DbContextOptionsBuilder<BlogDbContext>()
+           .UseInMemoryDatabase("BlobDb")
+           .Options;
+        blogDbContext = new BlogDbContext(contextOption);
+        blogDbContext.Articles.Add(new() { Id = 1, Title = startsWithN });
+        blogDbContext.Articles.Add(new() { Id = 2, Title = containsN });
+        blogDbContext.Articles.Add(new() { Id = 3, Title = endsWithN });
+        blogDbContext.Articles.Add(new() { Id = 4, Title = notIncludeN });
+        blogDbContext.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        if (blogDbContext is not null)
+        {
+            blogDbContext.Dispose();
+        }
+    }
+}

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/DatabaseFixture.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/DatabaseFixture.cs
@@ -5,19 +5,21 @@ public class DatabaseFixture : IDisposable
     public string startsWithN = "nop";
     public string containsN = "mnp";
     public string endsWithN = "lmn";
-    public string notIncludeN = "abc";
+    public string notContainsN = "abc";
     public BlogDbContext? blogDbContext;
 
     public DatabaseFixture()
     {
-        DbContextOptions<BlogDbContext> contextOption = new DbContextOptionsBuilder<BlogDbContext>()
+        var contextOption = new DbContextOptionsBuilder<BlogDbContext>()
            .UseInMemoryDatabase("BlobDb")
            .Options;
+
         blogDbContext = new BlogDbContext(contextOption);
         blogDbContext.Articles.Add(new() { Id = 1, Title = startsWithN });
         blogDbContext.Articles.Add(new() { Id = 2, Title = containsN });
         blogDbContext.Articles.Add(new() { Id = 3, Title = endsWithN });
-        blogDbContext.Articles.Add(new() { Id = 4, Title = notIncludeN });
+        blogDbContext.Articles.Add(new() { Id = 4, Title = notContainsN });
+
         blogDbContext.SaveChanges();
     }
 

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/LINQLikeOperatorTests.csproj
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/LINQLikeOperatorTests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LINQLikeOperator\LINQLikeOperator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/LINQLikeOperatorUnitTest.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/LINQLikeOperatorUnitTest.cs
@@ -1,0 +1,55 @@
+namespace LINQLikeOperatorTests;
+
+public class LINQLikeOperatorUnitTest : IClassFixture<DatabaseFixture>
+{
+    private DatabaseFixture fixture;
+
+    public LINQLikeOperatorUnitTest(DatabaseFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+
+    [Fact]
+    public void WhenQueryKeywordWithWhereAndContains_ThenCorrectArticles()
+    {
+        // Arrange
+        BlogDbContext blogDbContext = fixture.blogDbContext!;
+
+        // Act
+        List<Article> articles = blogDbContext.Articles.Where(x => x.Title.Contains("n")).ToList();
+
+        // Assert
+        Assert.True(articles.Count == 3);
+        Assert.Contains(fixture.startsWithN, articles.Select(x => x.Title));
+        Assert.Contains(fixture.containsN, articles.Select(x => x.Title));
+        Assert.Contains(fixture.endsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(fixture.notIncludeN, articles.Select(x => x.Title));
+    }
+
+    [Fact]
+    public void WhenQueryKeywordWithCountAndContains_ThenCorrectCount()
+    {
+        // Arrange
+        BlogDbContext blogDbContext = fixture.blogDbContext!;
+
+        // Act
+        int articleCounts = blogDbContext.Articles.Count(x => x.Title.Contains("n"));
+
+        // Assert
+        Assert.Equal(3, articleCounts);
+    }
+
+    [Fact]
+    public void WhenQueryKeywordWithFirstOrDefaultAndContains_ThenCorrectArticle()
+    {
+        // Arrange
+        BlogDbContext blogDbContext = fixture.blogDbContext!;
+
+        // Act
+        Article? firstArticle = blogDbContext.Articles.FirstOrDefault(x => x.Title.Contains("n"));
+
+        // Assert
+        Assert.Contains(fixture.startsWithN, firstArticle!.Title);
+    }
+}

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/LINQLikeOperatorUnitTest.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/LINQLikeOperatorUnitTest.cs
@@ -2,54 +2,70 @@ namespace LINQLikeOperatorTests;
 
 public class LINQLikeOperatorUnitTest : IClassFixture<DatabaseFixture>
 {
-    private DatabaseFixture fixture;
+    private readonly BlogDbContext _blogDbContext;
+    private readonly string _startsWithN;
+    private readonly string _containsN;
+    private readonly string _endsWithN;
+    private readonly string _notContainsN;
 
     public LINQLikeOperatorUnitTest(DatabaseFixture fixture)
     {
-        this.fixture = fixture;
+        _blogDbContext = fixture.blogDbContext!;
+        _startsWithN = fixture.startsWithN;
+        _containsN = fixture.containsN;
+        _endsWithN = fixture.endsWithN;
+        _notContainsN = fixture.notContainsN;
     }
-
 
     [Fact]
     public void WhenQueryKeywordWithWhereAndContains_ThenCorrectArticles()
     {
-        // Arrange
-        BlogDbContext blogDbContext = fixture.blogDbContext!;
+        List<Article> articles = _blogDbContext.Articles.Where(x => x.Title.Contains("n")).ToList();
 
-        // Act
-        List<Article> articles = blogDbContext.Articles.Where(x => x.Title.Contains("n")).ToList();
-
-        // Assert
         Assert.True(articles.Count == 3);
-        Assert.Contains(fixture.startsWithN, articles.Select(x => x.Title));
-        Assert.Contains(fixture.containsN, articles.Select(x => x.Title));
-        Assert.Contains(fixture.endsWithN, articles.Select(x => x.Title));
-        Assert.DoesNotContain(fixture.notIncludeN, articles.Select(x => x.Title));
+        Assert.Contains(_startsWithN, articles.Select(x => x.Title));
+        Assert.Contains(_containsN, articles.Select(x => x.Title));
+        Assert.Contains(_endsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_notContainsN, articles.Select(x => x.Title));
     }
 
     [Fact]
     public void WhenQueryKeywordWithCountAndContains_ThenCorrectCount()
     {
-        // Arrange
-        BlogDbContext blogDbContext = fixture.blogDbContext!;
+        int articleCounts = _blogDbContext.Articles.Count(x => x.Title.Contains("n"));
 
-        // Act
-        int articleCounts = blogDbContext.Articles.Count(x => x.Title.Contains("n"));
-
-        // Assert
         Assert.Equal(3, articleCounts);
     }
 
     [Fact]
     public void WhenQueryKeywordWithFirstOrDefaultAndContains_ThenCorrectArticle()
     {
-        // Arrange
-        BlogDbContext blogDbContext = fixture.blogDbContext!;
+        Article? firstArticle = _blogDbContext.Articles.FirstOrDefault(x => x.Title.Contains("n"));
 
-        // Act
-        Article? firstArticle = blogDbContext.Articles.FirstOrDefault(x => x.Title.Contains("n"));
+        Assert.Contains(_startsWithN, firstArticle!.Title);
+    }
 
-        // Assert
-        Assert.Contains(fixture.startsWithN, firstArticle!.Title);
+    [Fact]
+    public void WhenQueryKeywordWithWhereAndStartsWith_ThenCorrectArticles()
+    {
+        List<Article> articles = _blogDbContext.Articles.Where(x => x.Title.StartsWith("n")).ToList();
+
+        Assert.True(articles.Count == 1);
+        Assert.Contains(_startsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_containsN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_endsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_notContainsN, articles.Select(x => x.Title));
+    }
+
+    [Fact]
+    public void WhenQueryKeywordWithWhereAndEndsWith_ThenCorrectArticles()
+    {
+        List<Article> articles = _blogDbContext.Articles.Where(x => x.Title.EndsWith("n")).ToList();
+
+        Assert.True(articles.Count == 1);
+        Assert.DoesNotContain(_startsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_containsN, articles.Select(x => x.Title));
+        Assert.Contains(_endsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_notContainsN, articles.Select(x => x.Title));
     }
 }

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/LINQLikeOperatorUnitTest.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/LINQLikeOperatorUnitTest.cs
@@ -2,37 +2,29 @@ namespace LINQLikeOperatorTests;
 
 public class LINQLikeOperatorUnitTest : IClassFixture<DatabaseFixture>
 {
-    private readonly BlogDbContext _blogDbContext;
-    private readonly string _startsWithN;
-    private readonly string _containsN;
-    private readonly string _endsWithN;
-    private readonly string _notContainsN;
+    private readonly DatabaseFixture _fixture;
 
     public LINQLikeOperatorUnitTest(DatabaseFixture fixture)
     {
-        _blogDbContext = fixture.blogDbContext!;
-        _startsWithN = fixture.startsWithN;
-        _containsN = fixture.containsN;
-        _endsWithN = fixture.endsWithN;
-        _notContainsN = fixture.notContainsN;
+        _fixture = fixture;
     }
 
     [Fact]
     public void WhenQueryKeywordWithWhereAndContains_ThenCorrectArticles()
     {
-        List<Article> articles = _blogDbContext.Articles.Where(x => x.Title.Contains("n")).ToList();
+        List<Article> articles = _fixture.blogDbContext!.Articles.Where(x => x.Title.Contains("n")).ToList();
 
         Assert.True(articles.Count == 3);
-        Assert.Contains(_startsWithN, articles.Select(x => x.Title));
-        Assert.Contains(_containsN, articles.Select(x => x.Title));
-        Assert.Contains(_endsWithN, articles.Select(x => x.Title));
-        Assert.DoesNotContain(_notContainsN, articles.Select(x => x.Title));
+        Assert.Contains(_fixture.startsWithN, articles.Select(x => x.Title));
+        Assert.Contains(_fixture.containsN, articles.Select(x => x.Title));
+        Assert.Contains(_fixture.endsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_fixture.notContainsN, articles.Select(x => x.Title));
     }
 
     [Fact]
     public void WhenQueryKeywordWithCountAndContains_ThenCorrectCount()
     {
-        int articleCounts = _blogDbContext.Articles.Count(x => x.Title.Contains("n"));
+        int articleCounts = _fixture.blogDbContext!.Articles.Count(x => x.Title.Contains("n"));
 
         Assert.Equal(3, articleCounts);
     }
@@ -40,32 +32,32 @@ public class LINQLikeOperatorUnitTest : IClassFixture<DatabaseFixture>
     [Fact]
     public void WhenQueryKeywordWithFirstOrDefaultAndContains_ThenCorrectArticle()
     {
-        Article? firstArticle = _blogDbContext.Articles.FirstOrDefault(x => x.Title.Contains("n"));
+        Article? firstArticle = _fixture.blogDbContext!.Articles.FirstOrDefault(x => x.Title.Contains("n"));
 
-        Assert.Contains(_startsWithN, firstArticle!.Title);
+        Assert.Contains(_fixture.startsWithN, firstArticle!.Title);
     }
 
     [Fact]
     public void WhenQueryKeywordWithWhereAndStartsWith_ThenCorrectArticles()
     {
-        List<Article> articles = _blogDbContext.Articles.Where(x => x.Title.StartsWith("n")).ToList();
+        List<Article> articles = _fixture.blogDbContext!.Articles.Where(x => x.Title.StartsWith("n")).ToList();
 
         Assert.True(articles.Count == 1);
-        Assert.Contains(_startsWithN, articles.Select(x => x.Title));
-        Assert.DoesNotContain(_containsN, articles.Select(x => x.Title));
-        Assert.DoesNotContain(_endsWithN, articles.Select(x => x.Title));
-        Assert.DoesNotContain(_notContainsN, articles.Select(x => x.Title));
+        Assert.Contains(_fixture.startsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_fixture.containsN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_fixture.endsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_fixture.notContainsN, articles.Select(x => x.Title));
     }
 
     [Fact]
     public void WhenQueryKeywordWithWhereAndEndsWith_ThenCorrectArticles()
     {
-        List<Article> articles = _blogDbContext.Articles.Where(x => x.Title.EndsWith("n")).ToList();
+        List<Article> articles = _fixture.blogDbContext!.Articles.Where(x => x.Title.EndsWith("n")).ToList();
 
         Assert.True(articles.Count == 1);
-        Assert.DoesNotContain(_startsWithN, articles.Select(x => x.Title));
-        Assert.DoesNotContain(_containsN, articles.Select(x => x.Title));
-        Assert.Contains(_endsWithN, articles.Select(x => x.Title));
-        Assert.DoesNotContain(_notContainsN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_fixture.startsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_fixture.containsN, articles.Select(x => x.Title));
+        Assert.Contains(_fixture.endsWithN, articles.Select(x => x.Title));
+        Assert.DoesNotContain(_fixture.notContainsN, articles.Select(x => x.Title));
     }
 }

--- a/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/Usings.cs
+++ b/csharp-linq/LINQLikeOperator/LINQLikeOperatorTests/Usings.cs
@@ -1,0 +1,4 @@
+global using LINQLikeOperator;
+global using LINQLikeOperator.Models;
+global using Microsoft.EntityFrameworkCore;
+global using Xunit;


### PR DESCRIPTION
The How to Use SQL LIKE operator in C# LINQ sample code.
Both mdf and ldf files are not part of PR due to the .gitignore setting