### PR TITLE
bug fix performance test

### DIFF
--- a/collections-arrays/DeleteElementsFromArray/DeleteElementsFromArray/Methods/DeleteWithBufferCopy.cs
+++ b/collections-arrays/DeleteElementsFromArray/DeleteElementsFromArray/Methods/DeleteWithBufferCopy.cs
@@ -1,0 +1,23 @@
+﻿namespace DeleteElementsFromAnArray 
+{
+    public static partial class Methods 
+    {
+        public static int[] DeleteWithBufferCopy(int[] inputArray, int elementToRemove) 
+        {
+            var indexToRemove = Array.IndexOf(inputArray, elementToRemove);
+
+            if(indexToRemove < 0) 
+            {
+                return inputArray;
+            }
+
+            var newArray = new int[inputArray.Length - 1];
+
+            Buffer.BlockCopy(inputArray, 0, newArray, 0, indexToRemove *4);
+
+            Buffer.BlockCopy(inputArray, (indexToRemove + 1) * 4, newArray, indexToRemove * 4, (inputArray.Length - indexToRemove - 1) * 4);
+
+            return newArray;
+        }
+    }
+}

--- a/collections-arrays/DeleteElementsFromArray/DeleteElementsFromArrayUnitTests/DeleteElementsFromArrayUnitTests.cs
+++ b/collections-arrays/DeleteElementsFromArray/DeleteElementsFromArrayUnitTests/DeleteElementsFromArrayUnitTests.cs
@@ -106,6 +106,27 @@ namespace Tests
             CollectionAssert.AreEqual(value, expectedResult);
         }
 
+
+        [TestMethod]
+        public void GivenMethodBufferCopy_WhenDeleteElement3_ThenArray4557()
+        {
+            var key = 3;
+            var expectedResult = new int[] { 4, 5, 3, 5, 7 };
+            var value = Methods.DeleteWithBufferCopy(_myArray, key);
+
+            CollectionAssert.AreEqual(value, expectedResult);
+        }
+
+        [TestMethod]
+        public void GivenMethodBufferCopy_WhenDeleteElement6_ThenArray345357()
+        {
+            var key = 6;
+            var expectedResult = new int[] { 3, 4, 5, 3, 5, 7 };
+            var value = Methods.DeleteWithBufferCopy(_myArray, key);
+
+            CollectionAssert.AreEqual(value, expectedResult);
+        }
+
         [TestMethod]
         public void GivenMethodArraySegment_WhenDeleteElement3_ThenArray4557() 
         {


### PR DESCRIPTION
Hi, I read your blog post https://code-maze.com/csharp-how-to-delete-elements-from-an-array/ and thought that the DeleteWithArraySegment results did not look correct. There is a bug in the performance test that means when it is getting tested all the matching elements have been removed from the array. So it does nothing,

Fixed this, added Buffer.BlockCopy as it should be quicker. Add DeleteWithList as I can’t have Linq winning :-)
