### PR TITLE
ActionAndFuncDelegates Example Added

### DIFF
--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp.sln
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActionAndFuncDelegatesInCSharp", "ActionAndFuncDelegatesInCSharp.csproj", "{899D5359-7675-42EE-9899-9A819A361087}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActionAndFuncDelegatesInCSharp", "ActionAndFuncDelegatesInCSharp\ActionAndFuncDelegatesInCSharp.csproj", "{899D5359-7675-42EE-9899-9A819A361087}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActionAndFuncDelegatesInCSharpTests", "..\ActionAndFuncDelegatesInCSharpTests\ActionAndFuncDelegatesInCSharpTests.csproj", "{EB062F64-DA82-4748-A51B-606D4AD71468}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActionAndFuncDelegatesInCSharpTests", "ActionAndFuncDelegatesInCSharpTests\ActionAndFuncDelegatesInCSharpTests.csproj", "{EB062F64-DA82-4748-A51B-606D4AD71468}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp.csproj
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp.csproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{899D5359-7675-42EE-9899-9A819A361087}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ActionAndFuncDelegatesInCSharp</RootNamespace>
+    <AssemblyName>ActionAndFuncDelegatesInCSharp</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Delegates.cs" />
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp.sln
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActionAndFuncDelegatesInCSharp", "ActionAndFuncDelegatesInCSharp.csproj", "{899D5359-7675-42EE-9899-9A819A361087}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActionAndFuncDelegatesInCSharpTests", "..\ActionAndFuncDelegatesInCSharpTests\ActionAndFuncDelegatesInCSharpTests.csproj", "{EB062F64-DA82-4748-A51B-606D4AD71468}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{899D5359-7675-42EE-9899-9A819A361087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{899D5359-7675-42EE-9899-9A819A361087}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{899D5359-7675-42EE-9899-9A819A361087}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{899D5359-7675-42EE-9899-9A819A361087}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB062F64-DA82-4748-A51B-606D4AD71468}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB062F64-DA82-4748-A51B-606D4AD71468}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB062F64-DA82-4748-A51B-606D4AD71468}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB062F64-DA82-4748-A51B-606D4AD71468}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {166454DE-82B5-40D3-B54A-6D955D5FC95A}
+	EndGlobalSection
+EndGlobal

--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/App.config
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/Delegates.cs
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/Delegates.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ActionAndFuncDelegatesInCSharp
+{
+    public class Delegates
+    {
+        public static void DoAction(Action<int, string> action)
+        {
+            action(42, "hello");
+        }
+
+        public static int DoFunc(Func<int, int, int> func)
+        {
+            return func(10, 20);
+        }
+    }
+}

--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/Program.cs
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharp/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ActionAndFuncDelegatesInCSharp
+{
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+
+        }
+    }
+}

--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharpTests/ActionAndFuncDelegatesInCSharpTests.csproj
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharpTests/ActionAndFuncDelegatesInCSharpTests.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProjectGuid>{EB062F64-DA82-4748-A51B-606D4AD71468}</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>ActionAndFuncDelegatesInCSharpTests</RootNamespace>
+		<AssemblyName>ActionAndFuncDelegatesInCSharpTests</AssemblyName>
+		<TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+		<FileAlignment>512</FileAlignment>
+		<ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+		<VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+		<VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+		<ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+		<IsCodedUITest>False</IsCodedUITest>
+		<TestProjectType>UnitTest</TestProjectType>
+		<NuGetPackageImportStamp>
+		</NuGetPackageImportStamp>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+			<HintPath>..\ActionAndFuncDelegatesInCSharp\packages\MSTest.TestFramework.3.0.2\lib\net462\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+		</Reference>
+		<Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+			<HintPath>..\ActionAndFuncDelegatesInCSharp\packages\MSTest.TestFramework.3.0.2\lib\net462\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="DelegatesUnitTest.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="MSTest.TestAdapter" Version="3.0.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="packages.config" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ActionAndFuncDelegatesInCSharp\ActionAndFuncDelegatesInCSharp.csproj">
+			<Project>{899d5359-7675-42ee-9899-9a819a361087}</Project>
+			<Name>ActionAndFuncDelegatesInCSharp</Name>
+		</ProjectReference>
+	</ItemGroup>
+	<Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharpTests/DelegatesUnitTest.cs
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharpTests/DelegatesUnitTest.cs
@@ -1,0 +1,31 @@
+﻿using ActionAndFuncDelegatesInCSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace ActionAndFuncDelegatesInCSharpTests
+{
+    [TestClass]
+    public class DelegatesUnitTest
+    {
+        [TestMethod]
+        public void GivenAction_WhenInvoked_ThenActionExecuted()
+        {
+            bool actionExecuted = false;
+            Action<int, string> action = (i, s) => actionExecuted = true;
+
+            Delegates.DoAction(action);
+
+            Assert.IsTrue(actionExecuted);
+        }
+
+        [TestMethod]
+        public void GivenFunc_WhenInvoked_ThenFuncResultReturned()
+        {
+            Func<int, int, int> func = (x, y) => x + y;
+
+            int result = Delegates.DoFunc(func);
+
+            Assert.AreEqual(30, result);
+        }
+    }
+}

--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharpTests/Properties/AssemblyInfo.cs
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharpTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ActionAndFuncDelegatesInCSharpTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ActionAndFuncDelegatesInCSharpTests")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("eb062f64-da82-4748-a51b-606d4ad71468")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharpTests/packages.config
+++ b/csharp-basic-topics/ActionAndFuncDelegatesInCSharp/ActionAndFuncDelegatesInCSharpTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestFramework" version="3.0.2" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
Added example code for using `Action and Func` delegates in C#. Demonstrated how to use these delegates to pass methods as arguments and return values from methods.