### PR TITLE
Fix RemoveDuplicateElementsBenchmark, because the results were wrong

### DIFF
--- a/collections-arrays/RemoveDuplicatesFromAnArray/BenchmarkRunner/BenchmarkRunner.csproj
+++ b/collections-arrays/RemoveDuplicatesFromAnArray/BenchmarkRunner/BenchmarkRunner.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/collections-arrays/RemoveDuplicatesFromAnArray/BenchmarkRunner/RemoveDuplicateElementsBenchmark.cs
+++ b/collections-arrays/RemoveDuplicatesFromAnArray/BenchmarkRunner/RemoveDuplicateElementsBenchmark.cs
@@ -9,65 +9,104 @@ namespace BenchmarkRunner
     [Orderer(SummaryOrderPolicy.FastestToSlowest)]
     public class RemoveDuplicateElementsBenchmark
     {
-        private readonly RemoveDuplicateElements _duplicatesRemoval;
-        private readonly string[] _repeatedStrArray;
-
-        public RemoveDuplicateElementsBenchmark()
+        private readonly RemoveDuplicateElements _duplicatesRemoval = new RemoveDuplicateElements();
+        private int[]? _array;
+        
+        [Params(100, 10_000)]
+        public int N { get; set; }
+        
+        [Params(0, 25, 50, 75, 100)]
+        public int PercentDuplicates { get; set; }
+        
+        [GlobalSetup]
+        public void GlobalSetup()
         {
-            _duplicatesRemoval = new RemoveDuplicateElements();
-            _repeatedStrArray = Enumerable.Repeat("it", 50).Concat(Enumerable.Repeat("jump", 80)).Concat(Enumerable.Repeat("it", 70)).ToArray();
+            _array = ScrambleDuplicates(N, PercentDuplicates);
+        }
+        
+        // Returns an array of N integers with MPercent duplicates
+        private static int[] ScrambleDuplicates(int N, int MPercent)
+        {
+            // Calculate the number of duplicates to add
+            var M = (int)Math.Round(N * MPercent / 100.0);
+
+            // Create an array of N integers
+            var arr = new int[N];
+
+            // Fill the array with numbers from 1 to N
+            for (var i = 0; i < N; i++)
+                arr[i] = i + 1;
+
+            // Shuffle the array using Fisher-Yates algorithm
+            var rand = new Random();
+            for (var i = N - 1; i > 0; i--)
+            {
+                var j = rand.Next(i + 1);
+                var temp = arr[i];
+                arr[i] = arr[j];
+                arr[j] = temp;
+            }
+
+            // Add aprox. M duplicates to the array
+            for (var i = 0; i < M; i++)
+            {
+                var index = rand.Next(N);
+                arr[index] = arr[rand.Next(N)];
+            }
+
+            return arr;
         }
 
         [Benchmark]
         public void DistinctLINQMethod()
         {
-            _duplicatesRemoval.WithDistinctLINQMethod(_repeatedStrArray);
+            _duplicatesRemoval.WithDistinctLINQMethod(_array!);
         }
 
         [Benchmark]
         public void GroupByAndSelectLINQMethod()
         {
-            _duplicatesRemoval.WithGroupByAndSelectLINQMethod(_repeatedStrArray);
+            _duplicatesRemoval.WithGroupByAndSelectLINQMethod(_array!);
         }
 
         [Benchmark]
         public void HashingMethod()
         {
-            _duplicatesRemoval.ByHashing(_repeatedStrArray);
+            _duplicatesRemoval.ByHashing(_array!);
         }
 
         [Benchmark]
         public void ConversionToHashSet()
         {
-            _duplicatesRemoval.ByConvertingToHashSet(_repeatedStrArray);
+            _duplicatesRemoval.ByConvertingToHashSet(_array!);
         }
 
         [Benchmark]
         public void IterationAndShifting()
         {
-            _duplicatesRemoval.IterationAndShiftingElements(_repeatedStrArray);
+            _duplicatesRemoval.IterationAndShiftingElements(_array!);
         }
 
         [Benchmark]
         public void IterationAndSwapping()
         {
-            _duplicatesRemoval.IterationAndSwappingElements(_repeatedStrArray);
+            _duplicatesRemoval.IterationAndSwappingElements(_array!);
         }
         
         [Benchmark]
         public void IterationWithDictionary()
         {
-            _duplicatesRemoval.IterationWithDictionary(_repeatedStrArray);
+            _duplicatesRemoval.IterationWithDictionary(_array!);
         }
         [Benchmark]
         public void IterationWithDictionaryOpt()
         {
-            _duplicatesRemoval.IterationWithDictionaryOpt(_repeatedStrArray);
+            _duplicatesRemoval.IterationWithDictionaryOpt(_array!);
         }
         [Benchmark]
         public void RecursiveMethod()
         {
-            _duplicatesRemoval.RecursiveMethod(_repeatedStrArray);
+            _duplicatesRemoval.RecursiveMethod(_array!);
         }
     }
 }

--- a/collections-arrays/RemoveDuplicatesFromAnArray/RemoveDuplicatesFromAnArray/Program.cs
+++ b/collections-arrays/RemoveDuplicatesFromAnArray/RemoveDuplicatesFromAnArray/Program.cs
@@ -3,10 +3,10 @@
 class Program
 {
     private static readonly RemoveDuplicateElements _duplicatesRemoval = new RemoveDuplicateElements();
-    
+
     static void Main(string[] args)
     {
-        string[] arrayWithDuplicateValues = new string[] { "value1", "value1", "value2", "value2"};
+        var arrayWithDuplicateValues = new int[] { 1, 1, 2, 2 };
         Console.WriteLine("Input = {0}", string.Join(",", arrayWithDuplicateValues));
 
         Console.WriteLine();

--- a/collections-arrays/RemoveDuplicatesFromAnArray/RemoveDuplicatesFromAnArray/RemoveDuplicateElements.cs
+++ b/collections-arrays/RemoveDuplicatesFromAnArray/RemoveDuplicatesFromAnArray/RemoveDuplicateElements.cs
@@ -2,12 +2,12 @@
 
 public class RemoveDuplicateElements
 {
-    public string[] WithDistinctLINQMethod(string[] arrayWithDuplicateValues)
+    public int[] WithDistinctLINQMethod(int[] arrayWithDuplicateValues)
     {
         return arrayWithDuplicateValues.Distinct().ToArray();
     }
 
-    public string[] WithGroupByAndSelectLINQMethod(string[] arrayWithDuplicateValues)
+    public int[] WithGroupByAndSelectLINQMethod(int[] arrayWithDuplicateValues)
     {
         return arrayWithDuplicateValues.GroupBy(d => d).Select(d => d.First()).ToArray();
     }
@@ -24,7 +24,7 @@ public class RemoveDuplicateElements
     }
 
     // This method will re-arrange the elements in the array
-    public string[] IterationAndShiftingElements(string[] arrayWithDuplicateValues)
+    public int[] IterationAndShiftingElements(int[] arrayWithDuplicateValues)
     {
         var size = arrayWithDuplicateValues.Length;
 
@@ -47,7 +47,7 @@ public class RemoveDuplicateElements
         return arrayWithDuplicateValues[0..size];
     }
 
-    public string[] IterationAndSwappingElements(string[] arrayWithDuplicateValues)
+    public int[] IterationAndSwappingElements(int[] arrayWithDuplicateValues)
     {
         var size = arrayWithDuplicateValues.Length;
 
@@ -67,21 +67,21 @@ public class RemoveDuplicateElements
         return arrayWithDuplicateValues[0..size];
     }
 
-    public string[] IterationWithDictionary(string[] arrayWithDuplicateValues)
+    public int[] IterationWithDictionary(int[] arrayWithDuplicateValues)
     {
-        var dic = new Dictionary<string, int>();
+        var dic = new Dictionary<int, int>();
 
         foreach (var s in arrayWithDuplicateValues)
         {
             dic.TryAdd(s, 1);
         }
 
-        return dic.Select(x => x.Key.ToString()).ToArray();
+        return dic.Select(x => x.Key).ToArray();
     }
 
-    public string[] IterationWithDictionaryOpt(string[] arrayWithDuplicateValues)
+    public int[] IterationWithDictionaryOpt(int[] arrayWithDuplicateValues)
     {
-        var dic = new Dictionary<string, int>();
+        var dic = new Dictionary<int, int>();
 
         foreach (var s in arrayWithDuplicateValues)
         {
@@ -91,11 +91,11 @@ public class RemoveDuplicateElements
         return dic.Keys.ToArray();
     }
 
-    public string[] RecursiveMethod(string[] arrayWithDuplicateValues, List<string>? mem = default, int index = 0)
+    public int[] RecursiveMethod(int[] arrayWithDuplicateValues, List<int>? mem = default, int index = 0)
     {
         if (mem == null)
         {
-            mem = new List<string>();
+            mem = new List<int>();
         }
 
         if (index >= arrayWithDuplicateValues.Length)

--- a/collections-arrays/RemoveDuplicatesFromAnArray/Tests/Tests.cs
+++ b/collections-arrays/RemoveDuplicatesFromAnArray/Tests/Tests.cs
@@ -6,12 +6,12 @@ namespace Tests;
 public class Tests
 {
     private readonly RemoveDuplicateElements _duplicatesRemoval;
-    private string[] _arrayWithDuplicateValues;
+    private int[] _arrayWithDuplicateValues;
     
     public Tests()
     {
         _duplicatesRemoval = new RemoveDuplicateElements();
-        _arrayWithDuplicateValues = new string[] { "value1", "value1", "value2", "value2" };
+        _arrayWithDuplicateValues = new int[] { 1,1,2,2 };
     }
 
     [Fact]


### PR DESCRIPTION
- Upgrade to net7
- Switch from comparing speed on strings to comparing on ints
- Rewrite the 200 element array with 3 many duplicate strings to parametrized setup with N=100,10000 and Duplicates calculated by percentages 0,25,50,100

Because previous benchmark results were scewed towards O(n^2) algo as faster than O(n) algo, which is obviously bad result. Also benchmarking on comparing strings in the array might scew the results even further

Also wrote a comment to your article which is definitely wrong too, but can't edit that.
https://code-maze.com/csharp-array-remove-duplicates/