### PR TITLE
CM-726 Testing Using WireMock.NET

### DIFF
--- a/dotnet-client-libraries/WireMock.NET/WireMock.NET.Tests/PlanetsServiceTests.cs
+++ b/dotnet-client-libraries/WireMock.NET/WireMock.NET.Tests/PlanetsServiceTests.cs
@@ -33,14 +33,7 @@ namespace WireMock.NET.Tests
         public async Task GivenThatPlanetExists_WhenGetPlanetByIdIsInvoked_ThenValidPlanetIsReturned()
         {
             // Arrange
-            var planet = new Planet 
-            {
-                Id = 4, 
-                Name = "Mars", 
-                Diameter = 6779, 
-                NumberOfMoons = 2, 
-                HasAtmosphere = true
-            };
+            var planet = new Planet(4, "Mars", 6779, 2, true);
 
             _mockServer
                 .Given(

--- a/dotnet-client-libraries/WireMock.NET/WireMock.NET.Tests/PlanetsServiceTests.cs
+++ b/dotnet-client-libraries/WireMock.NET/WireMock.NET.Tests/PlanetsServiceTests.cs
@@ -33,27 +33,31 @@ namespace WireMock.NET.Tests
         public async Task GivenThatPlanetExists_WhenGetPlanetByIdIsInvoked_ThenValidPlanetIsReturned()
         {
             // Arrange
-            var planet = new Planet(4, "Mars", 6779, 2, true);
+            var planet = new Planet 
+            {
+                Id = 4, 
+                Name = "Mars", 
+                Diameter = 6779, 
+                NumberOfMoons = 2, 
+                HasAtmosphere = true
+            };
 
-_mockServer
-    .Given(
-        Request.Create()
-            .UsingGet()
-            .WithPath("/planets/4"))
-    .RespondWith(
-        Response.Create()
-            .WithStatusCode(HttpStatusCode.OK)
-            .WithBodyAsJson(planet));
+            _mockServer
+                .Given(
+                    Request.Create()
+                        .UsingGet()
+                        .WithPath("/planets/4"))
+                .RespondWith(
+                    Response.Create()
+                        .WithStatusCode(HttpStatusCode.OK)
+                        .WithBodyAsJson(planet));
 
             // Act
             var result = await _planetService.GetPlanetByIdAsync(planet.Id);
 
             // Assert
             result.Should().NotBeNull();
-            result.Name.Should().Be(planet.Name);
-            result.Diameter.Should().Be(planet.Diameter);
-            result.NumberOfMoons.Should().Be(planet.NumberOfMoons);
-            result.HasAtmosphere.Should().Be(planet.HasAtmosphere);
+            result.Should().Be(planet);
         }
 
         [Fact]
@@ -63,11 +67,11 @@ _mockServer
             _mockServer
                 .Given(
                     Request.Create()
-                    .UsingGet()
-                    .WithPath("/planets/9"))
+                        .UsingGet()
+                        .WithPath("/planets/9"))
                 .RespondWith(
                     Response.Create()
-                    .WithStatusCode(HttpStatusCode.NotFound));
+                        .WithStatusCode(HttpStatusCode.NotFound));
 
             // Act
             var result = await _planetService.GetPlanetByIdAsync(9);

--- a/dotnet-client-libraries/WireMock.NET/WireMockNet/Planet.cs
+++ b/dotnet-client-libraries/WireMock.NET/WireMockNet/Planet.cs
@@ -1,11 +1,4 @@
 ﻿namespace WireMockNet
 {
-    public record class Planet
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public double Diameter { get; set; }
-        public int NumberOfMoons { get; set; }
-        public bool HasAtmosphere { get; set; }
-    }
+    public record class Planet(int Id, string Name, double Diameter, int NumberOfMoons, bool HasAtmosphere);
 }

--- a/dotnet-client-libraries/WireMock.NET/WireMockNet/Planet.cs
+++ b/dotnet-client-libraries/WireMock.NET/WireMockNet/Planet.cs
@@ -1,25 +1,11 @@
 ﻿namespace WireMockNet
 {
-    public class Planet
+    public record class Planet
     {
         public int Id { get; set; }
         public string Name { get; set; }
         public double Diameter { get; set; }
         public int NumberOfMoons { get; set; }
         public bool HasAtmosphere { get; set; }
-    
-        public Planet(
-            int id,
-            string name,
-            double diameter,
-            int numberOfMoons,
-            bool hasAtmosphere)
-        {
-            Id = id;
-            Name = name;
-            Diameter = diameter;
-            NumberOfMoons = numberOfMoons;
-            HasAtmosphere = hasAtmosphere;
-        }
     }
 }

--- a/dotnet-client-libraries/WireMock.NET/WireMockNet/PlanetsService.cs
+++ b/dotnet-client-libraries/WireMock.NET/WireMockNet/PlanetsService.cs
@@ -9,8 +9,7 @@ namespace WireMockNet
 
         public PlanetsService(HttpClient httpClient)
         {
-            _httpClient = httpClient ??
-                throw new ArgumentNullException(nameof(httpClient));
+            _httpClient = httpClient;
         }
 
         public async Task<Planet?> GetPlanetByIdAsync(int id)


### PR DESCRIPTION
Quick fixes for the article about using WireMock.NET for integration testing.

Includes switch to record class to make test slimmer and remove a redundant null check in the constructor of PlanetsService.