### PR TITLE
CM-720: Repair the ResizeToA5 method of Resizer class

### DIFF
--- a/dotnet-client-libraries/ITextMergingPDFs/ITextMergingPDFs/Resizer.cs
+++ b/dotnet-client-libraries/ITextMergingPDFs/ITextMergingPDFs/Resizer.cs
@@ -20,16 +20,9 @@ namespace ITextMergingPDFs
             {
                 var page = inputDocument.GetPage(i);
 
-                if (page.GetPageSize() == PageSize.A5)
-                {
-                    outputDocument.AddPage(page);
-                }
-                else
-                {
-                    var formXObject = page.CopyAsFormXObject(outputDocument);
-                    var pdfCanvas = new PdfCanvas(outputDocument.AddNewPage());
-                    pdfCanvas.AddXObjectFittedIntoRectangle(formXObject, new Rectangle(0, 0, a5PageWidth, a5PageHeight));
-                }
+                var formXObject = page.CopyAsFormXObject(outputDocument);
+                var pdfCanvas = new PdfCanvas(outputDocument.AddNewPage());
+                pdfCanvas.AddXObjectFittedIntoRectangle(formXObject, new Rectangle(0, 0, a5PageWidth, a5PageHeight));
             }
         }
     }


### PR DESCRIPTION
The `if` statement will never be true and the code `outputDocument.AddPage(page);` is wrong.