### PR TITLE
CM-925 - API Versioning in ASP.NET Core

### DIFF
--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV1Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV1Tests.cs
@@ -13,7 +13,7 @@ public class StringListControllerV1Tests : IClassFixture<WebApplicationFactory<P
 
     public StringListControllerV1Tests(WebApplicationFactory<Program> factory)
     {
-        var serviceUrl = "https://localhost:7114/";
+        const string serviceUrl = "https://localhost:7114/";
         _httpClient = factory.CreateClient();
         _httpClient.BaseAddress = new Uri(serviceUrl);
     }
@@ -23,9 +23,10 @@ public class StringListControllerV1Tests : IClassFixture<WebApplicationFactory<P
     {
         var json = await _httpClient.GetStringAsync("/api/StringList");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
-        Assert.StartsWith("B", (string?)strings[0]);
-        Assert.StartsWith("B", (string?)strings[1]);
+        Assert.StartsWith("S", (string?)strings[0]);
+        Assert.StartsWith("S", (string?)strings[1]);
     }
 
     [Fact]
@@ -33,6 +34,7 @@ public class StringListControllerV1Tests : IClassFixture<WebApplicationFactory<P
     {
         var json = await _httpClient.GetStringAsync("/api/StringList?api-version=1.0");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("B", (string?)strings[0]);
         Assert.StartsWith("B", (string?)strings[1]);

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV1Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV1Tests.cs
@@ -9,14 +9,12 @@ namespace Tests;
 
 public class StringListControllerV1Tests : IClassFixture<WebApplicationFactory<Program>>
 {
-    private HttpClient _httpClient;
-    private WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _httpClient;
 
     public StringListControllerV1Tests(WebApplicationFactory<Program> factory)
     {
-        _factory = factory;
         var serviceUrl = "https://localhost:7114/";
-        _httpClient = _factory.CreateClient();
+        _httpClient = factory.CreateClient();
         _httpClient.BaseAddress = new Uri(serviceUrl);
     }
 

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV1Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV1Tests.cs
@@ -26,8 +26,8 @@ namespace Tests
             var json = await _httpClient.GetStringAsync("/api/StringList");
             var strings = JArray.Parse(json);
             Assert.Equal(2, strings.Count);
-            Assert.StartsWith("B", (string)strings[0]);
-            Assert.StartsWith("B", (string)strings[1]);
+            Assert.StartsWith("B", (string?)strings[0]);
+            Assert.StartsWith("B", (string?)strings[1]);
         }
 
         [Fact]
@@ -36,8 +36,8 @@ namespace Tests
             var json = await _httpClient.GetStringAsync("/api/StringList?api-version=1.0");
             var strings = JArray.Parse(json);
             Assert.Equal(2, strings.Count);
-            Assert.StartsWith("B", (string)strings[0]);
-            Assert.StartsWith("B", (string)strings[1]);
+            Assert.StartsWith("B", (string?)strings[0]);
+            Assert.StartsWith("B", (string?)strings[1]);
         }
     }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV1Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV1Tests.cs
@@ -5,39 +5,38 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Tests
+namespace Tests;
+
+public class StringListControllerV1Tests : IClassFixture<WebApplicationFactory<Program>>
 {
-    public class StringListControllerV1Tests : IClassFixture<WebApplicationFactory<Program>>
+    private HttpClient _httpClient;
+    private WebApplicationFactory<Program> _factory;
+
+    public StringListControllerV1Tests(WebApplicationFactory<Program> factory)
     {
-        private HttpClient _httpClient;
-        private WebApplicationFactory<Program> _factory;
+        _factory = factory;
+        var serviceUrl = "https://localhost:7114/";
+        _httpClient = _factory.CreateClient();
+        _httpClient.BaseAddress = new Uri(serviceUrl);
+    }
 
-        public StringListControllerV1Tests(WebApplicationFactory<Program> factory)
-        {
-            _factory = factory;
-            var serviceUrl = "https://localhost:7114/";
-            _httpClient = _factory.CreateClient();
-            _httpClient.BaseAddress = new Uri(serviceUrl);
-        }
+    [Fact]
+    public async Task GivenDefaultCall_WhenNoVersion_ThenReturnStringStartingWithB()
+    {
+        var json = await _httpClient.GetStringAsync("/api/StringList");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("B", (string?)strings[0]);
+        Assert.StartsWith("B", (string?)strings[1]);
+    }
 
-        [Fact]
-        public async Task GivenDefaultCall_WhenNoVersion_ThenReturnStringStartingWithB()
-        {
-            var json = await _httpClient.GetStringAsync("/api/StringList");
-            var strings = JArray.Parse(json);
-            Assert.Equal(2, strings.Count);
-            Assert.StartsWith("B", (string?)strings[0]);
-            Assert.StartsWith("B", (string?)strings[1]);
-        }
-
-        [Fact]
-        public async Task GivenQueryString_WhenCalledV1_ThenReturnStringStartingWithB()
-        {
-            var json = await _httpClient.GetStringAsync("/api/StringList?api-version=1.0");
-            var strings = JArray.Parse(json);
-            Assert.Equal(2, strings.Count);
-            Assert.StartsWith("B", (string?)strings[0]);
-            Assert.StartsWith("B", (string?)strings[1]);
-        }
+    [Fact]
+    public async Task GivenQueryString_WhenCalledV1_ThenReturnStringStartingWithB()
+    {
+        var json = await _httpClient.GetStringAsync("/api/StringList?api-version=1.0");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("B", (string?)strings[0]);
+        Assert.StartsWith("B", (string?)strings[1]);
     }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
@@ -5,15 +5,15 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Tests
-{
-    public class StringListControllerV2Tests : IClassFixture<WebApplicationFactory<Program>>
-    {
-        private HttpClient _httpClient;
-        private WebApplicationFactory<Program> _factory;
+namespace Tests;
 
-        public StringListControllerV2Tests(WebApplicationFactory<Program> factory)
-        {
+public class StringListControllerV2Tests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private HttpClient _httpClient;
+    private WebApplicationFactory<Program> _factory;
+
+    public StringListControllerV2Tests(WebApplicationFactory<Program> factory)
+    {
             _factory = factory;
             var serviceUrl = "https://localhost:7114/";
             _httpClient = _factory.CreateClient();
@@ -21,9 +21,9 @@ namespace Tests
         }
         
 
-        [Fact]
-        public async Task GivenQueryString_WhenCalledV2_ThenReturnStringStartingWithS()
-        {
+    [Fact]
+    public async Task GivenQueryString_WhenCalledV2_ThenReturnStringStartingWithS()
+    {
             var json = await _httpClient.GetStringAsync("/api/StringList?api-version=2.0");
             var strings = JArray.Parse(json);
             Assert.Equal(2, strings.Count);
@@ -32,9 +32,9 @@ namespace Tests
         }
 
 
-        [Fact]
-        public async Task GivenHeader_WhenCalledV2_ThenReturnStringStartingWithS()
-        {
+    [Fact]
+    public async Task GivenHeader_WhenCalledV2_ThenReturnStringStartingWithS()
+    {
             _httpClient.DefaultRequestHeaders.Add("X-Version", "2.0");
             var json = await _httpClient.GetStringAsync("/api/StringList");
             var strings = JArray.Parse(json);
@@ -43,9 +43,9 @@ namespace Tests
             Assert.StartsWith("S", (string?)strings[1]);
         }
 
-        [Fact]
-        public async Task GivenMediaType_WhenCalledV2_ThenReturnStringStartingWithS()
-        {
+    [Fact]
+    public async Task GivenMediaType_WhenCalledV2_ThenReturnStringStartingWithS()
+    {
             _httpClient.DefaultRequestHeaders.Add("Accept", "application/json; ver=2.0 ");
             var json = await _httpClient.GetStringAsync("/api/StringList");
             var strings = JArray.Parse(json);
@@ -53,5 +53,4 @@ namespace Tests
             Assert.StartsWith("S", (string?)strings[0]);
             Assert.StartsWith("S", (string?)strings[1]);
         }
-    }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
@@ -27,8 +27,8 @@ namespace Tests
             var json = await _httpClient.GetStringAsync("/api/StringList?api-version=2.0");
             var strings = JArray.Parse(json);
             Assert.Equal(2, strings.Count);
-            Assert.StartsWith("S", (string)strings[0]);
-            Assert.StartsWith("S", (string)strings[1]);
+            Assert.StartsWith("S", (string?)strings[0]);
+            Assert.StartsWith("S", (string?)strings[1]);
         }
 
 
@@ -39,8 +39,8 @@ namespace Tests
             var json = await _httpClient.GetStringAsync("/api/StringList");
             var strings = JArray.Parse(json);
             Assert.Equal(2, strings.Count);
-            Assert.StartsWith("S", (string)strings[0]);
-            Assert.StartsWith("S", (string)strings[1]);
+            Assert.StartsWith("S", (string?)strings[0]);
+            Assert.StartsWith("S", (string?)strings[1]);
         }
 
         [Fact]
@@ -50,8 +50,8 @@ namespace Tests
             var json = await _httpClient.GetStringAsync("/api/StringList");
             var strings = JArray.Parse(json);
             Assert.Equal(2, strings.Count);
-            Assert.StartsWith("S", (string)strings[0]);
-            Assert.StartsWith("S", (string)strings[1]);
+            Assert.StartsWith("S", (string?)strings[0]);
+            Assert.StartsWith("S", (string?)strings[1]);
         }
     }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
@@ -14,41 +14,41 @@ public class StringListControllerV2Tests : IClassFixture<WebApplicationFactory<P
     public StringListControllerV2Tests(WebApplicationFactory<Program> factory)
     {
         var serviceUrl = "https://localhost:7114/";
-            _httpClient = factory.CreateClient();
-            _httpClient.BaseAddress = new Uri(serviceUrl);
-        }
-        
+        _httpClient = factory.CreateClient();
+        _httpClient.BaseAddress = new Uri(serviceUrl);
+    }
+
 
     [Fact]
     public async Task GivenQueryString_WhenCalledV2_ThenReturnStringStartingWithS()
     {
-            var json = await _httpClient.GetStringAsync("/api/StringList?api-version=2.0");
-            var strings = JArray.Parse(json);
-            Assert.Equal(2, strings.Count);
-            Assert.StartsWith("S", (string?)strings[0]);
-            Assert.StartsWith("S", (string?)strings[1]);
-        }
+        var json = await _httpClient.GetStringAsync("/api/StringList?api-version=2.0");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("S", (string?)strings[0]);
+        Assert.StartsWith("S", (string?)strings[1]);
+    }
 
 
     [Fact]
     public async Task GivenHeader_WhenCalledV2_ThenReturnStringStartingWithS()
     {
-            _httpClient.DefaultRequestHeaders.Add("X-Version", "2.0");
-            var json = await _httpClient.GetStringAsync("/api/StringList");
-            var strings = JArray.Parse(json);
-            Assert.Equal(2, strings.Count);
-            Assert.StartsWith("S", (string?)strings[0]);
-            Assert.StartsWith("S", (string?)strings[1]);
-        }
+        _httpClient.DefaultRequestHeaders.Add("X-Version", "2.0");
+        var json = await _httpClient.GetStringAsync("/api/StringList");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("S", (string?)strings[0]);
+        Assert.StartsWith("S", (string?)strings[1]);
+    }
 
     [Fact]
     public async Task GivenMediaType_WhenCalledV2_ThenReturnStringStartingWithS()
     {
-            _httpClient.DefaultRequestHeaders.Add("Accept", "application/json; ver=2.0 ");
-            var json = await _httpClient.GetStringAsync("/api/StringList");
-            var strings = JArray.Parse(json);
-            Assert.Equal(2, strings.Count);
-            Assert.StartsWith("S", (string?)strings[0]);
-            Assert.StartsWith("S", (string?)strings[1]);
-        }
+        _httpClient.DefaultRequestHeaders.Add("Accept", "application/json; ver=2.0 ");
+        var json = await _httpClient.GetStringAsync("/api/StringList");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("S", (string?)strings[0]);
+        Assert.StartsWith("S", (string?)strings[1]);
+    }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
@@ -13,7 +13,7 @@ public class StringListControllerV2Tests : IClassFixture<WebApplicationFactory<P
 
     public StringListControllerV2Tests(WebApplicationFactory<Program> factory)
     {
-        var serviceUrl = "https://localhost:7114/";
+        const string serviceUrl = "https://localhost:7114/";
         _httpClient = factory.CreateClient();
         _httpClient.BaseAddress = new Uri(serviceUrl);
     }
@@ -24,6 +24,7 @@ public class StringListControllerV2Tests : IClassFixture<WebApplicationFactory<P
     {
         var json = await _httpClient.GetStringAsync("/api/StringList?api-version=2.0");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("S", (string?)strings[0]);
         Assert.StartsWith("S", (string?)strings[1]);
@@ -36,6 +37,7 @@ public class StringListControllerV2Tests : IClassFixture<WebApplicationFactory<P
         _httpClient.DefaultRequestHeaders.Add("X-Version", "2.0");
         var json = await _httpClient.GetStringAsync("/api/StringList");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("S", (string?)strings[0]);
         Assert.StartsWith("S", (string?)strings[1]);
@@ -47,6 +49,7 @@ public class StringListControllerV2Tests : IClassFixture<WebApplicationFactory<P
         _httpClient.DefaultRequestHeaders.Add("Accept", "application/json; ver=2.0 ");
         var json = await _httpClient.GetStringAsync("/api/StringList");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("S", (string?)strings[0]);
         Assert.StartsWith("S", (string?)strings[1]);

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV2Tests.cs
@@ -9,14 +9,12 @@ namespace Tests;
 
 public class StringListControllerV2Tests : IClassFixture<WebApplicationFactory<Program>>
 {
-    private HttpClient _httpClient;
-    private WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _httpClient;
 
     public StringListControllerV2Tests(WebApplicationFactory<Program> factory)
     {
-            _factory = factory;
-            var serviceUrl = "https://localhost:7114/";
-            _httpClient = _factory.CreateClient();
+        var serviceUrl = "https://localhost:7114/";
+            _httpClient = factory.CreateClient();
             _httpClient.BaseAddress = new Uri(serviceUrl);
         }
         

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
@@ -4,29 +4,28 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
-namespace Tests
-{
-    public class StringListControllerV3Tests : IClassFixture<WebApplicationFactory<Program>>
-    {
-        private HttpClient _httpClient;
-        private WebApplicationFactory<Program> _factory;
+namespace Tests;
 
-        public StringListControllerV3Tests(WebApplicationFactory<Program> factory)
-        {
+public class StringListControllerV3Tests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private HttpClient _httpClient;
+    private WebApplicationFactory<Program> _factory;
+
+    public StringListControllerV3Tests(WebApplicationFactory<Program> factory)
+    {
             _factory = factory;
             var serviceUrl = "https://localhost:7114/";
             _httpClient = _factory.CreateClient();
             _httpClient.BaseAddress = new Uri(serviceUrl);
         }
 
-        [Fact]
-        public async Task GivenURLChange_WhenCalledV3_ThenReturnStringStartingWithC()
-        {
+    [Fact]
+    public async Task GivenURLChange_WhenCalledV3_ThenReturnStringStartingWithC()
+    {
             var json = await _httpClient.GetStringAsync("/api/v3/StringList");
             var strings = JArray.Parse(json);
             Assert.Equal(2, strings.Count);
             Assert.StartsWith("C", (string?)strings[0]);
             Assert.StartsWith("C", (string?)strings[1]);
         }
-    }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
@@ -25,8 +25,8 @@ namespace Tests
             var json = await _httpClient.GetStringAsync("/api/v3/StringList");
             var strings = JArray.Parse(json);
             Assert.Equal(2, strings.Count);
-            Assert.StartsWith("C", (string)strings[0]);
-            Assert.StartsWith("C", (string)strings[1]);
+            Assert.StartsWith("C", (string?)strings[0]);
+            Assert.StartsWith("C", (string?)strings[1]);
         }
     }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
@@ -13,17 +13,17 @@ public class StringListControllerV3Tests : IClassFixture<WebApplicationFactory<P
     public StringListControllerV3Tests(WebApplicationFactory<Program> factory)
     {
         var serviceUrl = "https://localhost:7114/";
-            _httpClient = factory.CreateClient();
-            _httpClient.BaseAddress = new Uri(serviceUrl);
-        }
+        _httpClient = factory.CreateClient();
+        _httpClient.BaseAddress = new Uri(serviceUrl);
+    }
 
     [Fact]
     public async Task GivenURLChange_WhenCalledV3_ThenReturnStringStartingWithC()
     {
-            var json = await _httpClient.GetStringAsync("/api/v3/StringList");
-            var strings = JArray.Parse(json);
-            Assert.Equal(2, strings.Count);
-            Assert.StartsWith("C", (string?)strings[0]);
-            Assert.StartsWith("C", (string?)strings[1]);
-        }
+        var json = await _httpClient.GetStringAsync("/api/v3/StringList");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("C", (string?)strings[0]);
+        Assert.StartsWith("C", (string?)strings[1]);
+    }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
@@ -8,14 +8,12 @@ namespace Tests;
 
 public class StringListControllerV3Tests : IClassFixture<WebApplicationFactory<Program>>
 {
-    private HttpClient _httpClient;
-    private WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _httpClient;
 
     public StringListControllerV3Tests(WebApplicationFactory<Program> factory)
     {
-            _factory = factory;
-            var serviceUrl = "https://localhost:7114/";
-            _httpClient = _factory.CreateClient();
+        var serviceUrl = "https://localhost:7114/";
+            _httpClient = factory.CreateClient();
             _httpClient.BaseAddress = new Uri(serviceUrl);
         }
 

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListControllerV3Tests.cs
@@ -12,7 +12,7 @@ public class StringListControllerV3Tests : IClassFixture<WebApplicationFactory<P
 
     public StringListControllerV3Tests(WebApplicationFactory<Program> factory)
     {
-        var serviceUrl = "https://localhost:7114/";
+        const string serviceUrl = "https://localhost:7114/";
         _httpClient = factory.CreateClient();
         _httpClient.BaseAddress = new Uri(serviceUrl);
     }
@@ -22,6 +22,7 @@ public class StringListControllerV3Tests : IClassFixture<WebApplicationFactory<P
     {
         var json = await _httpClient.GetStringAsync("/api/v3/StringList");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("C", (string?)strings[0]);
         Assert.StartsWith("C", (string?)strings[1]);

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV1Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV1Tests.cs
@@ -19,13 +19,14 @@ public class StringListMinimalV1Tests : IClassFixture<WebApplicationFactory<Prog
     }
 
     [Fact]
-    public async Task GivenDefaultCall_WhenNoVersion_ThenReturnStringStartingWithB()
+    public async Task GivenDefaultCall_WhenNoVersion_ThenReturnStringStartingWithS()
     {
         var json = await _httpClient.GetStringAsync("/api/minimal/StringList");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
-        Assert.StartsWith("B", (string?)strings[0]);
-        Assert.StartsWith("B", (string?)strings[1]);
+        Assert.StartsWith("S", (string?)strings[0]);
+        Assert.StartsWith("S", (string?)strings[1]);
     }
 
     [Fact]
@@ -33,6 +34,7 @@ public class StringListMinimalV1Tests : IClassFixture<WebApplicationFactory<Prog
     {
         var json = await _httpClient.GetStringAsync("/api/minimal/StringList?api-version=1.0");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("B", (string?)strings[0]);
         Assert.StartsWith("B", (string?)strings[1]);

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV1Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV1Tests.cs
@@ -9,14 +9,12 @@ namespace Tests;
 
 public class StringListMinimalV1Tests : IClassFixture<WebApplicationFactory<Program>>
 {
-    private HttpClient _httpClient;
-    private WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _httpClient;
 
     public StringListMinimalV1Tests(WebApplicationFactory<Program> factory)
     {
-        _factory = factory;
         var serviceUrl = "https://localhost:7114/";
-        _httpClient = _factory.CreateClient();
+        _httpClient = factory.CreateClient();
         _httpClient.BaseAddress = new Uri(serviceUrl);
     }
 

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV1Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV1Tests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests;
+
+public class StringListMinimalV1Tests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private HttpClient _httpClient;
+    private WebApplicationFactory<Program> _factory;
+
+    public StringListMinimalV1Tests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        var serviceUrl = "https://localhost:7114/";
+        _httpClient = _factory.CreateClient();
+        _httpClient.BaseAddress = new Uri(serviceUrl);
+    }
+
+    [Fact]
+    public async Task GivenDefaultCall_WhenNoVersion_ThenReturnStringStartingWithB()
+    {
+        var json = await _httpClient.GetStringAsync("/api/minimal/StringList");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("B", (string?)strings[0]);
+        Assert.StartsWith("B", (string?)strings[1]);
+    }
+
+    [Fact]
+    public async Task GivenQueryString_WhenCalledV1_ThenReturnStringStartingWithB()
+    {
+        var json = await _httpClient.GetStringAsync("/api/minimal/StringList?api-version=1.0");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("B", (string?)strings[0]);
+        Assert.StartsWith("B", (string?)strings[1]);
+    }
+}

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV2Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV2Tests.cs
@@ -9,14 +9,12 @@ namespace Tests;
 
 public class StringListMinimalV2Tests : IClassFixture<WebApplicationFactory<Program>>
 {
-    private HttpClient _httpClient;
-    private WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _httpClient;
 
     public StringListMinimalV2Tests(WebApplicationFactory<Program> factory)
     {
-        _factory = factory;
         var serviceUrl = "https://localhost:7114/";
-        _httpClient = _factory.CreateClient();
+        _httpClient = factory.CreateClient();
         _httpClient.BaseAddress = new Uri(serviceUrl);
     }
 

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV2Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV2Tests.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests;
+
+public class StringListMinimalV2Tests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private HttpClient _httpClient;
+    private WebApplicationFactory<Program> _factory;
+
+    public StringListMinimalV2Tests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        var serviceUrl = "https://localhost:7114/";
+        _httpClient = _factory.CreateClient();
+        _httpClient.BaseAddress = new Uri(serviceUrl);
+    }
+
+
+    [Fact]
+    public async Task GivenQueryString_WhenCalledV2_ThenReturnStringStartingWithS()
+    {
+        var json = await _httpClient.GetStringAsync("/api/minimal/StringList?api-version=2.0");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("S", (string?)strings[0]);
+        Assert.StartsWith("S", (string?)strings[1]);
+    }
+
+
+    [Fact]
+    public async Task GivenHeader_WhenCalledV2_ThenReturnStringStartingWithS()
+    {
+        _httpClient.DefaultRequestHeaders.Add("X-Version", "2.0");
+        var json = await _httpClient.GetStringAsync("/api/minimal/StringList");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("S", (string?)strings[0]);
+        Assert.StartsWith("S", (string?)strings[1]);
+    }
+
+    [Fact]
+    public async Task GivenMediaType_WhenCalledV2_ThenReturnStringStartingWithS()
+    {
+        _httpClient.DefaultRequestHeaders.Add("Accept", "application/json; ver=2.0 ");
+        var json = await _httpClient.GetStringAsync("/api/minimal/StringList");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("S", (string?)strings[0]);
+        Assert.StartsWith("S", (string?)strings[1]);
+    }
+}

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV2Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV2Tests.cs
@@ -13,7 +13,7 @@ public class StringListMinimalV2Tests : IClassFixture<WebApplicationFactory<Prog
 
     public StringListMinimalV2Tests(WebApplicationFactory<Program> factory)
     {
-        var serviceUrl = "https://localhost:7114/";
+        const string serviceUrl = "https://localhost:7114/";
         _httpClient = factory.CreateClient();
         _httpClient.BaseAddress = new Uri(serviceUrl);
     }
@@ -24,6 +24,7 @@ public class StringListMinimalV2Tests : IClassFixture<WebApplicationFactory<Prog
     {
         var json = await _httpClient.GetStringAsync("/api/minimal/StringList?api-version=2.0");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("S", (string?)strings[0]);
         Assert.StartsWith("S", (string?)strings[1]);
@@ -36,6 +37,7 @@ public class StringListMinimalV2Tests : IClassFixture<WebApplicationFactory<Prog
         _httpClient.DefaultRequestHeaders.Add("X-Version", "2.0");
         var json = await _httpClient.GetStringAsync("/api/minimal/StringList");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("S", (string?)strings[0]);
         Assert.StartsWith("S", (string?)strings[1]);
@@ -47,6 +49,7 @@ public class StringListMinimalV2Tests : IClassFixture<WebApplicationFactory<Prog
         _httpClient.DefaultRequestHeaders.Add("Accept", "application/json; ver=2.0 ");
         var json = await _httpClient.GetStringAsync("/api/minimal/StringList");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("S", (string?)strings[0]);
         Assert.StartsWith("S", (string?)strings[1]);

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV3Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV3Tests.cs
@@ -8,14 +8,12 @@ namespace Tests;
 
 public class StringListMinimalV3Tests : IClassFixture<WebApplicationFactory<Program>>
 {
-    private HttpClient _httpClient;
-    private WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _httpClient;
 
     public StringListMinimalV3Tests(WebApplicationFactory<Program> factory)
     {
-        _factory = factory;
         var serviceUrl = "https://localhost:7114/";
-        _httpClient = _factory.CreateClient();
+        _httpClient = factory.CreateClient();
         _httpClient.BaseAddress = new Uri(serviceUrl);
     }
 

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV3Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV3Tests.cs
@@ -12,7 +12,7 @@ public class StringListMinimalV3Tests : IClassFixture<WebApplicationFactory<Prog
 
     public StringListMinimalV3Tests(WebApplicationFactory<Program> factory)
     {
-        var serviceUrl = "https://localhost:7114/";
+        const string serviceUrl = "https://localhost:7114/";
         _httpClient = factory.CreateClient();
         _httpClient.BaseAddress = new Uri(serviceUrl);
     }
@@ -22,6 +22,7 @@ public class StringListMinimalV3Tests : IClassFixture<WebApplicationFactory<Prog
     {
         var json = await _httpClient.GetStringAsync("/api/minimal/v3/StringList");
         var strings = JArray.Parse(json);
+
         Assert.Equal(2, strings.Count);
         Assert.StartsWith("C", (string?)strings[0]);
         Assert.StartsWith("C", (string?)strings[1]);

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV3Tests.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/StringListMinimalV3Tests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+namespace Tests;
+
+public class StringListMinimalV3Tests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private HttpClient _httpClient;
+    private WebApplicationFactory<Program> _factory;
+
+    public StringListMinimalV3Tests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        var serviceUrl = "https://localhost:7114/";
+        _httpClient = _factory.CreateClient();
+        _httpClient.BaseAddress = new Uri(serviceUrl);
+    }
+
+    [Fact]
+    public async Task GivenURLChange_WhenCalledV3_ThenReturnStringStartingWithC()
+    {
+        var json = await _httpClient.GetStringAsync("/api/minimal/v3/StringList");
+        var strings = JArray.Parse(json);
+        Assert.Equal(2, strings.Count);
+        Assert.StartsWith("C", (string?)strings[0]);
+        Assert.StartsWith("C", (string?)strings[1]);
+    }
+}

--- a/aspnetcore-webapi/VersioningRestAPI/Tests/Tests.csproj
+++ b/aspnetcore-webapi/VersioningRestAPI/Tests/Tests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Data.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Data.cs
@@ -1,10 +1,9 @@
-﻿namespace VersioningRestAPI
+﻿namespace VersioningRestAPI;
+
+public class Data
 {
-    public class Data
-    {
-        public static readonly string[] Summaries = new[]
+    public static readonly string[] Summaries = new[]
         {
             "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
         };
-    }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
@@ -33,10 +33,10 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-// v1
-var versionSetV1 = app.NewApiVersionSet()
+var apiVersionSet = app.NewApiVersionSet()
     .HasDeprecatedApiVersion(new ApiVersion(0, 9))
     .HasApiVersion(new ApiVersion(1, 0))
+    .HasApiVersion(new ApiVersion(2, 0))
     .ReportApiVersions()
     .Build();
 
@@ -45,21 +45,19 @@ app.MapGet("api/minimal/StringList", () =>
     var strings = Data.Summaries.Where(x => x.StartsWith("B"));
 
     return TypedResults.Ok(strings);
-
-}).WithApiVersionSet(versionSetV1);
-
-// v2
-var versionSetV2 = app.NewApiVersionSet()
-    .HasApiVersion(new ApiVersion(2, 0))
-    .ReportApiVersions()
-    .Build();
+})
+    .WithApiVersionSet(apiVersionSet)
+    .MapToApiVersion(new ApiVersion(0, 9))
+    .MapToApiVersion(new ApiVersion(1, 0));
 
 app.MapGet("api/minimal/StringList", () =>
 {
     var strings = Data.Summaries.Where(x => x.StartsWith("S"));
 
     return TypedResults.Ok(strings);
-}).WithApiVersionSet(versionSetV2);
+})
+    .WithApiVersionSet(apiVersionSet)
+    .MapToApiVersion(new ApiVersion(2, 0));
 
 app.Run();
 

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
@@ -37,6 +37,7 @@ var apiVersionSet = app.NewApiVersionSet()
     .HasDeprecatedApiVersion(new ApiVersion(0, 9))
     .HasApiVersion(new ApiVersion(1, 0))
     .HasApiVersion(new ApiVersion(2, 0))
+    .HasApiVersion(new ApiVersion(3, 0))
     .ReportApiVersions()
     .Build();
 
@@ -58,6 +59,15 @@ app.MapGet("api/minimal/StringList", () =>
 })
     .WithApiVersionSet(apiVersionSet)
     .MapToApiVersion(new ApiVersion(2, 0));
+
+app.MapGet("api/minimal/v{version:apiVersion}/StringList", () =>
+{
+    var strings = Data.Summaries.Where(x => x.StartsWith("C"));
+
+    return TypedResults.Ok(strings);
+})
+    .WithApiVersionSet(apiVersionSet)
+    .MapToApiVersion(new ApiVersion(3, 0));
 
 app.Run();
 

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
@@ -1,4 +1,5 @@
 using Asp.Versioning;
+using VersioningRestAPI;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -31,6 +32,34 @@ app.UseHttpsRedirection();
 app.UseAuthorization();
 
 app.MapControllers();
+
+// v1
+var versionSetV1 = app.NewApiVersionSet()
+    .HasDeprecatedApiVersion(new ApiVersion(0, 9))
+    .HasApiVersion(new ApiVersion(1, 0))
+    .ReportApiVersions()
+    .Build();
+
+app.MapGet("api/minimal/StringList", () =>
+{
+    var strings = Data.Summaries.Where(x => x.StartsWith("B"));
+
+    return TypedResults.Ok(strings);
+
+}).WithApiVersionSet(versionSetV1);
+
+// v2
+var versionSetV2 = app.NewApiVersionSet()
+    .HasApiVersion(new ApiVersion(2, 0))
+    .ReportApiVersions()
+    .Build();
+
+app.MapGet("api/minimal/StringList", () =>
+{
+    var strings = Data.Summaries.Where(x => x.StartsWith("S"));
+
+    return TypedResults.Ok(strings);
+}).WithApiVersionSet(versionSetV2);
 
 app.Run();
 

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
@@ -9,13 +9,12 @@ builder.Services.AddEndpointsApiExplorer();
 var apiVersioningBuilder = builder.Services.AddApiVersioning(o =>
 {
     o.AssumeDefaultVersionWhenUnspecified = true;
-    o.DefaultApiVersion = new ApiVersion(1, 0);
+    o.DefaultApiVersion = new ApiVersion(2, 0);
     o.ReportApiVersions = true;
     o.ApiVersionReader = ApiVersionReader.Combine(
         new QueryStringApiVersionReader("api-version"),
         new HeaderApiVersionReader("X-Version"),
         new MediaTypeApiVersionReader("ver"));
-
 });
 
 apiVersioningBuilder.AddApiExplorer(
@@ -34,8 +33,7 @@ app.UseAuthorization();
 app.MapControllers();
 
 var apiVersionSet = app.NewApiVersionSet()
-    .HasDeprecatedApiVersion(new ApiVersion(0, 9))
-    .HasApiVersion(new ApiVersion(1, 0))
+    .HasDeprecatedApiVersion(new ApiVersion(1, 0))
     .HasApiVersion(new ApiVersion(2, 0))
     .HasApiVersion(new ApiVersion(3, 0))
     .ReportApiVersions()
@@ -48,7 +46,6 @@ app.MapGet("api/minimal/StringList", () =>
     return TypedResults.Ok(strings);
 })
     .WithApiVersionSet(apiVersionSet)
-    .MapToApiVersion(new ApiVersion(0, 9))
     .MapToApiVersion(new ApiVersion(1, 0));
 
 app.MapGet("api/minimal/StringList", () =>

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/Program.cs
@@ -1,14 +1,14 @@
-using Microsoft.AspNetCore.Mvc.Versioning;
+using Asp.Versioning;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 
-builder.Services.AddApiVersioning(o =>
+var apiVersioningBuilder = builder.Services.AddApiVersioning(o =>
 {
     o.AssumeDefaultVersionWhenUnspecified = true;
-    o.DefaultApiVersion = new Microsoft.AspNetCore.Mvc.ApiVersion(1, 0);
+    o.DefaultApiVersion = new ApiVersion(1, 0);
     o.ReportApiVersions = true;
     o.ApiVersionReader = ApiVersionReader.Combine(
         new QueryStringApiVersionReader("api-version"),
@@ -16,13 +16,13 @@ builder.Services.AddApiVersioning(o =>
         new MediaTypeApiVersionReader("ver"));
 
 });
-builder.Services.AddVersionedApiExplorer(
+
+apiVersioningBuilder.AddApiExplorer(
     options =>
     {
         options.GroupNameFormat = "'v'VVV";
         options.SubstituteApiVersionInUrl = true;
     });
-
 
 var app = builder.Build();
 

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V1/Controllers/StringListController.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V1/Controllers/StringListController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
 namespace VersioningRestAPI.V1.Controllers

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V1/Controllers/StringListController.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V1/Controllers/StringListController.cs
@@ -5,8 +5,7 @@ namespace VersioningRestAPI.V1.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[ApiVersion("0.9", Deprecated = true)]
-[ApiVersion("1.0")]
+[ApiVersion("1.0", Deprecated = true)]
 public class StringListController : ControllerBase
 {
     [HttpGet()]        

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V1/Controllers/StringListController.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V1/Controllers/StringListController.cs
@@ -1,18 +1,17 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
-namespace VersioningRestAPI.V1.Controllers
+namespace VersioningRestAPI.V1.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[ApiVersion("0.9", Deprecated = true)]
+[ApiVersion("1.0")]
+public class StringListController : ControllerBase
 {
-    [ApiController]
-    [Route("api/[controller]")]
-    [ApiVersion("0.9", Deprecated = true)]
-    [ApiVersion("1.0")]
-    public class StringListController : ControllerBase
+    [HttpGet()]        
+    public IEnumerable<string> Get()
     {
-        [HttpGet()]        
-        public IEnumerable<string> Get()
-        {
-            return Data.Summaries.Where(x => x.StartsWith("B"));
-        }
+        return Data.Summaries.Where(x => x.StartsWith("B"));
     }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V2/Controllers/StringListController.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V2/Controllers/StringListController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 
 namespace VersioningRestAPI.V2.Controllers
 {

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V2/Controllers/StringListController.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V2/Controllers/StringListController.cs
@@ -1,17 +1,16 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
-namespace VersioningRestAPI.V2.Controllers
+namespace VersioningRestAPI.V2.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[ApiVersion("2.0")]
+public class StringListController : Controller
 {
-    [ApiController]
-    [Route("api/[controller]")]
-    [ApiVersion("2.0")]
-    public class StringListController : Controller
+    [HttpGet()]
+    public IEnumerable<string> Get()
     {
-        [HttpGet()]
-        public IEnumerable<string> Get()
-        {
-            return Data.Summaries.Where(x => x.StartsWith("S"));
-        }
+        return Data.Summaries.Where(x => x.StartsWith("S"));
     }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V3/Controllers/StringListController.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V3/Controllers/StringListController.cs
@@ -1,17 +1,16 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 
-namespace VersioningRestAPI.V3.Controllers
+namespace VersioningRestAPI.V3.Controllers;
+
+[ApiController]
+[Route("api/v{version:apiVersion}/StringList")]
+[ApiVersion("3.0")]
+public class StringListController : Controller
 {
-    [ApiController]
-    [Route("api/v{version:apiVersion}/StringList")]
-    [ApiVersion("3.0")]
-    public class StringListController : Controller
+    [HttpGet()]
+    public IEnumerable<string> Get()
     {
-        [HttpGet()]
-        public IEnumerable<string> Get()
-        {
-            return Data.Summaries.Where(x => x.StartsWith("C"));
-        }
+        return Data.Summaries.Where(x => x.StartsWith("C"));
     }
 }

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V3/Controllers/StringListController.cs
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/V3/Controllers/StringListController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 
 namespace VersioningRestAPI.V3.Controllers
 {

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/VersioningRestAPI.csproj
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/VersioningRestAPI.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Http" Version="8.0.0" />
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.0.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
   </ItemGroup>

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/VersioningRestAPI.csproj
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/VersioningRestAPI.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/VersioningRestAPI.csproj
+++ b/aspnetcore-webapi/VersioningRestAPI/VersioningRestAPI/VersioningRestAPI.csproj
@@ -6,8 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Changes:

- updated versioning packages to be compatible with .NET 8,
- refactored code & eliminated null warnings,
- added examples & tests for versioning of the minimal APIs.