### PR TITLE
CM- 916 || Escaping the Backslash in C#

### DIFF
--- a/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/EscapingBackSlash.sln
+++ b/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/EscapingBackSlash.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33424.131
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EscapingBackSlash", "EscapingBackSlash\EscapingBackSlash.csproj", "{3F905F42-1595-4657-8F03-5B50C103FAC5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{6A22D6EB-B792-4F8F-9992-6316E02AE9BB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3F905F42-1595-4657-8F03-5B50C103FAC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F905F42-1595-4657-8F03-5B50C103FAC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F905F42-1595-4657-8F03-5B50C103FAC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F905F42-1595-4657-8F03-5B50C103FAC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A22D6EB-B792-4F8F-9992-6316E02AE9BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A22D6EB-B792-4F8F-9992-6316E02AE9BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A22D6EB-B792-4F8F-9992-6316E02AE9BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A22D6EB-B792-4F8F-9992-6316E02AE9BB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AEE77C33-CA4A-4E53-B137-75806FD5CE1B}
+	EndGlobalSection
+EndGlobal

--- a/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/EscapingBackSlash/EscapingBackSlash.csproj
+++ b/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/EscapingBackSlash/EscapingBackSlash.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/EscapingBackSlash/Program.cs
+++ b/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/EscapingBackSlash/Program.cs
@@ -1,0 +1,32 @@
+﻿public static class BackslashMethods
+{
+    public static string UsingDoubleBackslash()
+    {
+        return "C:\\Users\\User\\Documents";
+    }
+
+    public static string UsingVerbatimStringLiteral()
+    {
+        return @"C:\Users\User\Documents";
+    }
+
+    public static string UsingUnicodeEscapeSequence()
+    {
+        return "C:\u005CUsers\u005CUser\u005CDocuments";
+    }
+
+    public static string UsingStringFormat()
+    {
+        return string.Format("C:{0}Users{0}User{0}Documents", Path.DirectorySeparatorChar);
+    }
+
+    public static string UsingStringInterpolation()
+    {
+        return $"C:{Path.DirectorySeparatorChar}Users{Path.DirectorySeparatorChar}User{Path.DirectorySeparatorChar}Documents";
+    }
+
+    public static void Main(string[] args)
+    {
+        
+    }
+}

--- a/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/Tests/Tests.cs
+++ b/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/Tests/Tests.cs
@@ -1,0 +1,37 @@
+namespace Tests;
+
+[TestClass]
+public class Tests
+{
+    private const string path = "C:\\Users\\User\\Documents";
+
+    [TestMethod]
+    public void GivenDoubleBackslash_WhenCallingMethod_ThenReturnEscapedFilePath()
+    {
+        Assert.AreEqual(path, BackslashMethods.UsingDoubleBackslash());
+    }
+
+    [TestMethod]
+    public void GivenVerbatimStringLiteral_WhenCallingMethod_ThenReturnFilePathWithVerbatimString()
+    {
+        Assert.AreEqual(path, BackslashMethods.UsingVerbatimStringLiteral());
+    }
+
+    [TestMethod]
+    public void GivenUnicodeEscapeSequence_WhenCallingMethod_ThenReturnFilePathWithUnicodeEscape()
+    {
+        Assert.AreEqual(path, BackslashMethods.UsingUnicodeEscapeSequence());
+    }
+
+    [TestMethod]
+    public void GivenStringFormatMethod_WhenCallingMethod_ThenReturnFormattedFilePath()
+    {
+        Assert.AreEqual(path, BackslashMethods.UsingStringFormat());
+    }
+
+    [TestMethod]
+    public void GivenStringInterpolation_WhenCallingMethod_ThenReturnInterpolatedFilePath()
+    {
+        Assert.AreEqual(path, BackslashMethods.UsingStringInterpolation());
+    }
+}

--- a/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/Tests/Tests.csproj
+++ b/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/Tests/Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+    <ItemGroup>
+	    <ProjectReference Include="..\EscapingBackSlash\EscapingBackSlash.csproj" />
+    </ItemGroup>
+</Project>

--- a/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/Tests/Usings.cs
+++ b/csharp-basic-topics/EscapingBackSlashInCSharp/EscapingBackSlash/Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
This PR contains different ways to incorporate a literal backslash onto a C# string,