### PR TITLE
Restore per-article PR builds via GitHub Actions

### DIFF
--- a/.github/ci-skip-folders.txt
+++ b/.github/ci-skip-folders.txt
@@ -1,0 +1,29 @@
+# Article folders excluded from PR CI builds.
+#
+# One "<category>/<article>" path per line (exactly as it appears at the repo root,
+# e.g. "dotnet-efcore/EfCoreInterceptors"). Blank lines and lines starting with "#"
+# are ignored. Edit this file directly to add or remove a folder -- no workflow
+# (.yml) changes needed.
+
+# Live-integration tests: hit a real external DB, no DB available on the runner.
+dotnet-efcore/TestForValidDbConnection
+dotnet-efcore/OptimisticVsPessimisticLocking
+dotnet-efcore/EfCoreInterceptors
+
+# docker-compose-dependent: needs external infra (Kafka / OTel collector) the
+# runner doesn't provide.
+aspnetcore-webapi/Kafka
+dotnet-client-libraries/OpenTelemetryCollector
+
+# Windows-only (WPF / *-windows TFM / classic .NET Framework). This workflow runs
+# on Linux runners only, matching how the old Jenkins setup always worked.
+threads-csharp/MultithreadingInCsharp
+dotnet-platform-specific/HowToForceRunDotNetApplicationAsAdministrator
+csharp-intermediate-topics/FlagsAttributeForEnum
+
+# Dead/broken example (targets netcoreapp1.1; no current SDK builds it). Predates
+# this workflow and is unrelated to any CI change -- not worth chasing.
+visual-studio/ChangeLanguageVersionForAllProjects
+
+# Pins its own SDK via a local global.json; excluded rather than special-cased.
+dotnet-projects/SwitchingDotnetSdk

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,125 @@
+# Advisory only. This check is never marked as a required status check, and main
+# has no branch protection rule referencing it. It builds and tests exactly the
+# article folder(s) a PR touches -- nothing else. Folders in .github/ci-skip-folders.txt
+# are filtered out before the matrix is built, so they never show up as a run,
+# passing or failing (edit that file, not this one, to change what's excluded).
+name: PR Build
+
+on:
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same PR when new commits land.
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  detect-changes:
+    name: Detect changed article folders
+    runs-on: ubuntu-latest
+    outputs:
+      folders: ${{ steps.compute.outputs.folders }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute changed, buildable folders
+        id: compute
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          SKIP_FILE=".github/ci-skip-folders.txt"
+
+          # Skip list: strip comments and blank lines.
+          mapfile -t skip_list < <(
+            sed 's/\r$//' "$SKIP_FILE" | grep -vE '^\s*#' | grep -vE '^\s*$'
+          )
+
+          is_skipped() {
+            local f="$1"
+            for s in "${skip_list[@]:-}"; do
+              [ "$f" = "$s" ] && return 0
+            done
+            return 1
+          }
+
+          # Reduce every changed path to its "<category>/<article>" prefix.
+          # Every article folder in this repo is exactly two levels deep.
+          mapfile -t folders < <(
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+              | awk -F/ 'NF>=2 {print $1"/"$2}' \
+              | sort -u
+          )
+
+          entries="[]"
+          for f in "${folders[@]:-}"; do
+            [ -z "$f" ] && continue
+
+            if is_skipped "$f"; then
+              echo "::notice::Skipping '$f' -- listed in $SKIP_FILE."
+              continue
+            fi
+
+            # Folder may have been deleted in this PR -- skip if no .sln remains at HEAD.
+            if ! compgen -G "$f"/*.sln > /dev/null 2>&1; then
+              echo "::notice::Skipping '$f' -- no .sln at HEAD (deleted or restructured)."
+              continue
+            fi
+
+            entries=$(jq -c --arg folder "$f" '. + [{folder: $folder}]' <<<"$entries")
+          done
+
+          echo "folders=$entries" >> "$GITHUB_OUTPUT"
+          echo "Changed, buildable folders:"
+          echo "$entries" | jq .
+
+  build-and-test:
+    name: Build & test (${{ matrix.folder }})
+    needs: detect-changes
+    if: needs.detect-changes.outputs.folders != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.detect-changes.outputs.folders) }}
+    steps:
+      - name: Checkout (sparse)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            ${{ matrix.folder }}
+          sparse-checkout-cone-mode: true
+
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Build and test
+        working-directory: ${{ matrix.folder }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          sln=$(find . -maxdepth 1 -iname "*.sln" | head -n1)
+          if [ -z "$sln" ]; then
+            echo "::notice::No .sln found in ${{ matrix.folder }} -- skipping."
+            exit 0
+          fi
+          echo "Building $sln"
+          dotnet build "$sln" --configuration Release
+          echo "Testing $sln (no-op for folders with no test project)"
+          dotnet test "$sln" --configuration Release --no-build


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds and tests just the article folder(s) a PR actually touches, replacing the old Jenkins gate that never left any trace in this repo. Detection is a plain changed-folder diff filtered against `.github/ci-skip-folders.txt`, so known problem folders are never attempted rather than shown as failing. Runs on `ubuntu-latest` only. This check is advisory for now — it isn't required for merge, and `main` has no branch protection rule pointing at it.

Skip list and why:

| Folder | Reason |
|---|---|
| `dotnet-efcore/TestForValidDbConnection` | Live-integration test, hits a real DB connection |
| `dotnet-efcore/OptimisticVsPessimisticLocking` | Live-integration test, hits a real DB connection |
| `dotnet-efcore/EfCoreInterceptors` | Live-integration test, hits a real DB connection |
| `aspnetcore-webapi/Kafka` | Needs `docker-compose` (Kafka), no infra on hosted runners |
| `dotnet-client-libraries/OpenTelemetryCollector` | Needs `docker-compose` (OTel collector) |
| `threads-csharp/MultithreadingInCsharp` | WPF app — Windows-only, this workflow is Linux-only |
| `dotnet-platform-specific/HowToForceRunDotNetApplicationAsAdministrator` | `net7.0-windows`, Windows admin-elevation APIs |
| `csharp-intermediate-topics/FlagsAttributeForEnum` | `net48`, classic .NET Framework — Windows-only |
| `visual-studio/ChangeLanguageVersionForAllProjects` | Contains a `netcoreapp1.1` project; dead example, no current SDK builds it |
| `dotnet-projects/SwitchingDotnetSdk` | Pins its own SDK via `global.json`; excluded rather than special-cased |
