### PR TITLE
IntroductionToWolverineLibrary: retarget net10.0, WolverineFx 6.25.5, add RuntimeCompilation package

### DIFF
--- a/dotnet-client-libraries/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary.Tests/IntroductionToWolverineLibrary.Tests.csproj
+++ b/dotnet-client-libraries/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary.Tests/IntroductionToWolverineLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/dotnet-client-libraries/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary.csproj
+++ b/dotnet-client-libraries/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="WolverineFx" Version="2.15.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+    <PackageReference Include="WolverineFx" Version="6.25.5" />
+    <PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.25.5" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-client-libraries/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary/Program.cs
+++ b/dotnet-client-libraries/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary/Program.cs
@@ -3,8 +3,7 @@ using Wolverine;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddOpenApi();
 builder.Services.AddControllers();
 builder.Host.UseWolverine( x =>
 {
@@ -15,20 +14,17 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
 }
 
 app.UseHttpsRedirection();
 
 app.MapPost("/order", async (Order newOrder, IMessageBus bus) => await bus.InvokeAsync(newOrder))
-    .WithName("NewBookOrder")
-    .WithOpenApi();
+    .WithName("NewBookOrder");
 
-app.MapPost("/orderReply", async (Order newOrder, IMessageBus bus) => 
+app.MapPost("/orderReply", async (Order newOrder, IMessageBus bus) =>
     await bus.InvokeAsync<string>(newOrder))
-    .WithName("NewBookOrderReply")
-    .WithOpenApi();
+    .WithName("NewBookOrderReply");
 
 app.MapPost("/bookReview", async (BookReview review, IMessageBus bus) =>
 {
@@ -36,8 +32,7 @@ app.MapPost("/bookReview", async (BookReview review, IMessageBus bus) =>
 
     return Results.Ok("Book review submitted successfully.");
 })
-.WithName("BookReviewEndpoint")
-.WithOpenApi();
+.WithName("BookReviewEndpoint");
 
 
 app.MapControllers();

--- a/dotnet-client-libraries/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary/Properties/launchSettings.json
+++ b/dotnet-client-libraries/IntroductionToWolverineLibrary/IntroductionToWolverineLibrary/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "openapi/v1.json",
       "applicationUrl": "http://localhost:5137",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -23,7 +23,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "openapi/v1.json",
       "applicationUrl": "https://localhost:7125;http://localhost:5137",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -32,7 +32,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "openapi/v1.json",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
Retargets to net10.0, bumps WolverineFx to the 6.25.x line (6.25.5). Adds WolverineFx.RuntimeCompilation: 6.x split the runtime Roslyn compiler out of the core package, so UseWolverine() as shown in the article throws on startup without it. builder.Host.UseWolverine(...) registration itself is unchanged. 6/6 tests pass on net10.0.