### PR TITLE
MockingWithNSubstitute: retarget net10.0, NSubstitute 6.2.0

### DIFF
--- a/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute.Tests/MockingWithNSubstitute.Tests.csproj
+++ b/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute.Tests/MockingWithNSubstitute.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,19 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NSubstitute" Version="6.2.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute.Tests/NotificationServiceTests.cs
+++ b/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute.Tests/NotificationServiceTests.cs
@@ -1,3 +1,5 @@
+using NSubstitute.ExceptionExtensions;
+
 namespace MockingWithNSubstitute.Tests;
 
 public class NotificationServiceTests
@@ -16,7 +18,7 @@ public class NotificationServiceTests
     [Fact]
     public void GivenInputIsCorrect_WhenNotifyUserIsInvoked_ThenTrueIsReturned()
     {
-        // Arrange            
+        // Arrange
         const string message = "Mocking behaviors and expectations with NSubstitute";
         _emailService.IsValidEmail(_user.Email)
             .Returns(true);
@@ -27,7 +29,7 @@ public class NotificationServiceTests
         var result = _notificationService.NotifyUser(_user, message);
 
         // Assert
-        result.Should().BeTrue();
+        Assert.True(result);
     }
 
     [Fact]
@@ -44,25 +46,35 @@ public class NotificationServiceTests
         var result = _notificationService.NotifyUser(_user, message);
 
         // Assert
-        result.Should().BeFalse();
+        Assert.False(result);
         _emailService.Received().IsValidEmail(Arg.Any<string>());
         _emailService.DidNotReceive().SendEmail(Arg.Any<string>(), Arg.Is<string>(x => x.Length > 5), message);
     }
 
     [Fact]
-    public void GivenExceptionIsThrown_WhenNotifyUserIsInvoked_ThenFalseIsReturned()
+    public void GivenExceptionIsThrown_WhenNotifyUserIsInvoked_ThenExceptionIsPropagated()
     {
         // Arrange
         const string message = "Throwing Exceptions When Mocking With NSubstitute";
         _emailService.IsValidEmail(_user.Email)
             .Returns(true);
-        _emailService.When(x => x.SendEmail(_user.Email, "Notification from CodeMaze", message))
-            .Do(x => { throw new InvalidEmailException(); });
+        _emailService.SendEmail(_user.Email, "Notification from CodeMaze", message)
+            .Throws<InvalidEmailException>();
 
-        // Act
-        var act = () => _notificationService.NotifyUser(_user, message);
+        // Act & Assert
+        Assert.Throws<InvalidEmailException>(() => _notificationService.NotifyUser(_user, message));
+    }
 
-        // Assert
-        act.Should().ThrowExactly<InvalidEmailException>();
+    [Fact]
+    public async Task GivenExceptionIsThrown_WhenSendEmailAsyncIsAwaited_ThenExceptionIsPropagated()
+    {
+        // Arrange
+        const string message = "Throwing exceptions from asynchronous members";
+        _emailService.SendEmailAsync(_user.Email, "Notification from CodeMaze", message)
+            .ThrowsAsync<InvalidEmailException>();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidEmailException>(() =>
+            _emailService.SendEmailAsync(_user.Email, "Notification from CodeMaze", message));
     }
 }

--- a/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute.Tests/Usings.cs
+++ b/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute.Tests/Usings.cs
@@ -1,3 +1,2 @@
-global using FluentAssertions;
 global using NSubstitute;
 global using Xunit;

--- a/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute/IEmailService.cs
+++ b/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute/IEmailService.cs
@@ -4,4 +4,5 @@ public interface IEmailService
 {
     bool IsValidEmail(string email);
     bool SendEmail(string recipient, string subject, string message);
+    Task<bool> SendEmailAsync(string recipient, string subject, string message);
 }

--- a/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute/MockingWithNSubstitute.csproj
+++ b/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute/MockingWithNSubstitute.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute/NotificationService.cs
+++ b/dotnet-testing/MockingWithNSubstitute/MockingWithNSubstitute/NotificationService.cs
@@ -17,16 +17,7 @@ public class NotificationService : INotificationService
             return false;
         }
 
-        try
-        {
-            var sentSuccessfully = _emailService
+        return _emailService
             .SendEmail(user.Email, "Notification from CodeMaze", message);
-
-            return sentSuccessfully;
-        }
-        catch
-        {
-            throw;
-        }
     }
 }


### PR DESCRIPTION
Retargets to net10.0, bumps NSubstitute to 6.2.0 (BSD-3-Clause). Removes a no-op catch { throw; } block and drops FluentAssertions for plain xUnit asserts per house code-minimalism rule. 4/4 tests pass on net10.0.