### PR TITLE
Blazor Sections sample: retarget to net10.0

### DIFF
--- a/blazor-features/BlazorSections/BlazorWasmApp/BlazorWasmApp.csproj
+++ b/blazor-features/BlazorSections/BlazorWasmApp/BlazorWasmApp.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all"/>
     </ItemGroup>
 
 </Project>

--- a/blazor-features/BlazorSections/README.md
+++ b/blazor-features/BlazorSections/README.md
@@ -1,0 +1,9 @@
+# Blazor Sections
+
+Sample project for the "Blazor Sections: SectionOutlet and SectionContent" article.
+
+Standard Blazor WebAssembly Standalone App template (`net10.0`). The app has no server-rendering
+component, so it runs entirely in the browser under `InteractiveWebAssembly`-equivalent
+client-side rendering — there is only one render mode in play, which is why `SectionOutlet` and
+`SectionContent` resolve without the layout/page render-mode mismatch the article's "Interactive
+Render Modes" section describes for Blazor Web Apps.


### PR DESCRIPTION
Retargets the BlazorSections sample (BlazorWasmApp) from net8.0 to net10.0, bumps Blazor WebAssembly packages to 10.0.10, and adds a README stating the sample's render mode for the SEO-refreshed article at code-maze.com/how-to-use-sections-in-blazor/.