### PR TITLE
NetArchTest.Rules sample: retarget to net10.0

### DIFF
--- a/dotnet-testing/ArchitectureTestsWithNetArchTest/Api.Tests/Api.Tests.csproj
+++ b/dotnet-testing/ArchitectureTestsWithNetArchTest/Api.Tests/Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/dotnet-testing/ArchitectureTestsWithNetArchTest/Api/Api.csproj
+++ b/dotnet-testing/ArchitectureTestsWithNetArchTest/Api/Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/dotnet-testing/ArchitectureTestsWithNetArchTest/Architecture.Tests/Architecture.Tests.csproj
+++ b/dotnet-testing/ArchitectureTestsWithNetArchTest/Architecture.Tests/Architecture.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/dotnet-testing/ArchitectureTestsWithNetArchTest/Contracts/Contracts.csproj
+++ b/dotnet-testing/ArchitectureTestsWithNetArchTest/Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dotnet-testing/ArchitectureTestsWithNetArchTest/Domain/Domain.csproj
+++ b/dotnet-testing/ArchitectureTestsWithNetArchTest/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dotnet-testing/ArchitectureTestsWithNetArchTest/Persistence/Persistence.csproj
+++ b/dotnet-testing/ArchitectureTestsWithNetArchTest/Persistence/Persistence.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dotnet-testing/ArchitectureTestsWithNetArchTest/Services.Abstractions/Services.Abstractions.csproj
+++ b/dotnet-testing/ArchitectureTestsWithNetArchTest/Services.Abstractions/Services.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dotnet-testing/ArchitectureTestsWithNetArchTest/Services/Services.csproj
+++ b/dotnet-testing/ArchitectureTestsWithNetArchTest/Services/Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Retargets the ArchitectureTestsWithNetArchTest sample (article 109747) from net8.0 to net10.0. Bumps Microsoft.AspNetCore.Mvc.Testing 8.0.2 -> 10.0.10 in Api.Tests (the net8-era TestHost package throws on net10 System.Text.Json PipeWriter.UnflushedBytes contract, causing 500s on all Api.Tests integration tests under TestServer even though the app runs fine standalone). Build 0 errors, 11/11 tests pass (6 Architecture.Tests + 5 Api.Tests).