### PR TITLE
OnChangeEventWithSelectDropdown: retarget net10.0, fix @foreach compile bug, add InputSelect example

### DIFF
--- a/blazor-features/OnChangeEventWithSelectDropdown/OnChangeEventWithSelectDropdown/OnChangeEventWithSelectDropdown.csproj
+++ b/blazor-features/OnChangeEventWithSelectDropdown/OnChangeEventWithSelectDropdown/OnChangeEventWithSelectDropdown.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -13,8 +13,8 @@
     <ExternalConsole>true</ExternalConsole>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/blazor-features/OnChangeEventWithSelectDropdown/OnChangeEventWithSelectDropdown/Pages/Index.razor
+++ b/blazor-features/OnChangeEventWithSelectDropdown/OnChangeEventWithSelectDropdown/Pages/Index.razor
@@ -36,16 +36,35 @@
         <option value="@topping.Id">@topping.Name +$@topping.Price</option>
     }
 </select>
+<br/>
+<span>Fourth topping (InputSelect inside EditForm):</span>
+<EditForm Model="order">
+    <InputSelect @bind-Value="order.ToppingId" @bind-Value:after="RecalculateTotal">
+        @foreach (var topping in toppings)
+        {
+            <option value="@topping.Id">@topping.Name</option>
+        }
+    </InputSelect>
+</EditForm>
+<p>Fourth topping total: $@fourthTotal</p>
 
 @code
 {
     public record Topping(int Id, string Name, double Price);
+
+    public class Order
+    {
+        public int ToppingId { get; set; }
+    }
+
     public string? selectedTopping;
     public string? selectedSecondTopping;
     public string? selectedThirdTopping;
     public static double baseBurgerCost = 5.4;
     public double totalCost = baseBurgerCost;
     public double grandTotal;
+    public double fourthTotal;
+    public Order order = new();
 
     public List<Topping> toppings = new List<Topping>()
     {
@@ -59,26 +78,37 @@
 
     public void HandleChange(ChangeEventArgs args)
     {
-        @foreach (var topping in toppings)
+        if (!int.TryParse(args.Value?.ToString(), out var id))
         {
-            if (topping.Id == int.Parse(args.Value.ToString()))
-            {
-                selectedSecondTopping = topping.Name;
-                totalCost = Math.Round(baseBurgerCost + topping.Price, 2);
-            }
+            return;
         }
+
+        var topping = toppings.FirstOrDefault(t => t.Id == id);
+        if (topping is null)
+        {
+            return;
+        }
+
+        selectedSecondTopping = topping.Name;
+        totalCost = Math.Round(baseBurgerCost + topping.Price, 2);
     }
 
     public async Task CalculateGrandTotal()
     {
         await Task.Delay(2000);
 
-        @foreach (var topping in toppings)
+        foreach (var topping in toppings)
         {
             if (topping.Id == int.Parse(selectedThirdTopping))
             {
                 grandTotal = Math.Round(totalCost + topping.Price, 2);
             }
         }
+    }
+
+    public void RecalculateTotal()
+    {
+        var topping = toppings.FirstOrDefault(t => t.Id == order.ToppingId);
+        fourthTotal = topping is null ? 0 : Math.Round(baseBurgerCost + topping.Price, 2);
     }
 }

--- a/blazor-features/OnChangeEventWithSelectDropdown/OnChangeEventWithSelectDropdownTests/OnChangeEventWithSelectDropdownTests.csproj
+++ b/blazor-features/OnChangeEventWithSelectDropdown/OnChangeEventWithSelectDropdownTests/OnChangeEventWithSelectDropdownTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="bunit" Version="1.22.19" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="bunit" Version="1.40.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Retargets the sample to net10.0 (WebAssembly packages 10.0.10, test stack MSTest 4.3.3 / bunit 1.40.0). Fixes a compile bug: `@foreach` (Razor markup syntax) was used inside two C# method bodies (`HandleChange`, `CalculateGrandTotal`) where plain `foreach` is required - neither method compiled as published. `HandleChange` rewritten to a TryParse guard + FirstOrDefault lookup. Adds a fourth topping select using `InputSelect` inside `EditForm` with `@bind-Value:after` for the article's new section on handling InputSelect changes without losing the binding.