### PR TITLE
MockAsynchronousMethods: retarget net10.0, add plain-Task mock + Verify assertion

### DIFF
--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/ArticleRepositoryTests.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/ArticleRepositoryTests.cs
@@ -1,5 +1,8 @@
+using MockAsynchronousMethods.Repository.DbModels;
 using MockAsynchronousMethods.Repository.Tests.Mock;
 using MockAsynchronousMethods.Tests.Mock;
+using Moq;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -19,6 +22,7 @@ namespace MockAsynchronousMethods.Repository.Tests
 
             Assert.NotNull(result);
             Assert.Equal(FakeDb.Articles.First(), result);
+            mockArticleRepository.Verify(x => x.GetByIdAsync(1), Times.Once);
         }
 
         [Fact]
@@ -44,6 +48,20 @@ namespace MockAsynchronousMethods.Repository.Tests
 
             Assert.NotNull(result);
             Assert.True(result.Any());
+        }
+
+        [Fact]
+        public async Task GivenAMockedDatabase_WhenSavingAnArticleAsynchronously_ThenTheSaveCompletes()
+        {
+            var mockArticleRepository = new FakeDbArticleMock()
+                .SaveAsync();
+
+            var articleRepository = new ArticleRepository(mockArticleRepository.Object);
+            var article = new ArticleDbModel { Id = 4, Title = "Fourth Article", LastUpdate = DateTime.Now };
+
+            await articleRepository.SaveArticleAsync(article);
+
+            mockArticleRepository.Verify(x => x.SaveAsync(article), Times.Once);
         }
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/Mock/FakeDbArticleMock.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/Mock/FakeDbArticleMock.cs
@@ -3,6 +3,7 @@ using MockAsynchronousMethods.Repository.Interfaces;
 using MockAsynchronousMethods.Tests.Mock;
 using Moq;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace MockAsynchronousMethods.Repository.Tests.Mock
 {
@@ -28,6 +29,14 @@ namespace MockAsynchronousMethods.Repository.Tests.Mock
         {
             Setup(x => x.GetAsync())
                 .ReturnsAsync(FakeDb.Articles);
+
+            return this;
+        }
+
+        public FakeDbArticleMock SaveAsync()
+        {
+            Setup(x => x.SaveAsync(It.IsAny<ArticleDbModel>()))
+                .Returns(Task.CompletedTask);
 
             return this;
         }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/MockAsynchronousMethods.Tests.csproj
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/MockAsynchronousMethods.Tests.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/ArticleRepository.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/ArticleRepository.cs
@@ -21,5 +21,10 @@ namespace MockAsynchronousMethods.Repository
         {
             return await _fakeDbArticle.GetAsync();
         }
+
+        public Task SaveArticleAsync(ArticleDbModel article)
+        {
+            return _fakeDbArticle.SaveAsync(article);
+        }
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/FakeDatabase/FakeDbArticles.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/FakeDatabase/FakeDbArticles.cs
@@ -43,5 +43,12 @@ namespace MockAsynchronousMethods.Repository.FakeDatabase
         {
             return await Task.FromResult(_articles.FirstOrDefault(x => x.Id == id));
         }
+
+        public Task SaveAsync(ArticleDbModel article)
+        {
+            _articles.Add(article);
+
+            return Task.CompletedTask;
+        }
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/Interfaces/IArticleRepository.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/Interfaces/IArticleRepository.cs
@@ -6,5 +6,6 @@ namespace MockAsynchronousMethods.Repository.Interfaces
     {
         Task<ArticleDbModel?> GetArticleAsync(int id);
         Task<IEnumerable<ArticleDbModel>> GetAllArticlesAsync();
+        Task SaveArticleAsync(ArticleDbModel article);
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/Interfaces/IFakeDbArticles.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/Interfaces/IFakeDbArticles.cs
@@ -6,5 +6,6 @@ namespace MockAsynchronousMethods.Repository.Interfaces
     {
         Task<IEnumerable<ArticleDbModel>> GetAsync();
         Task<ArticleDbModel?> GetByIdAsync(int id);
+        Task SaveAsync(ArticleDbModel article);
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/MockAsynchronousMethods.Repository.csproj
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/MockAsynchronousMethods.Repository.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Closing as a duplicate: article 70683 was already shipped live on 2026-08-13 (post_modified confirms it) via an earlier, apparently untracked session. PR #2089 (2026-08-13) and #2090 (created ~21s before this one, evidence of a concurrent session running the same slot) already cover the identical repo change. Leaving reconciliation of which one to merge to that cleanup rather than adding a third duplicate.