### PR TITLE
DateTimeOffsetVsDateTime: retarget net10.0, add conversion example

### DIFF
--- a/dotnet-datetime/DateTimeOffsetVsDateTime/DateTimeOffsetVsDateTime.Tests/DateTimeOffsetVsDateTime.Tests.csproj
+++ b/dotnet-datetime/DateTimeOffsetVsDateTime/DateTimeOffsetVsDateTime.Tests/DateTimeOffsetVsDateTime.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/dotnet-datetime/DateTimeOffsetVsDateTime/DateTimeOffsetVsDateTime/DateTimeOffsetVsDateTime.csproj
+++ b/dotnet-datetime/DateTimeOffsetVsDateTime/DateTimeOffsetVsDateTime/DateTimeOffsetVsDateTime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dotnet-datetime/DateTimeOffsetVsDateTime/DateTimeOffsetVsDateTime/Program.cs
+++ b/dotnet-datetime/DateTimeOffsetVsDateTime/DateTimeOffsetVsDateTime/Program.cs
@@ -25,3 +25,10 @@ Console.WriteLine($"DateTime Kind: {dateTimeUnspecified.Kind}");
 
 var dateTimeOffsetUnspecified = DateTimeOffset.Now;
 Console.WriteLine($"DateTimeOffset Kind: {dateTimeOffsetUnspecified.DateTime.Kind}");
+
+//Converting DateTimeOffset to DateTime
+var moment = DateTimeOffset.Now;
+
+var forStorage = moment.UtcDateTime;      // Kind = Utc — safe to persist
+var forDisplay = moment.LocalDateTime;    // Kind = Local — server's zone
+var raw        = moment.DateTime;         // Kind = Unspecified — offset lost


### PR DESCRIPTION
Retargets the DateTimeOffsetVsDateTime sample to net10.0 and adds the UtcDateTime/LocalDateTime/DateTime conversion example used by the article rewrite. 4/4 tests pass.