### PR TITLE
MockAsynchronousMethods: retarget net10.0, add plain-Task mock + Verify assertion

### DIFF
--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/ArticleRepositoryTests.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/ArticleRepositoryTests.cs
@@ -1,5 +1,6 @@
 using MockAsynchronousMethods.Repository.Tests.Mock;
 using MockAsynchronousMethods.Tests.Mock;
+using Moq;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -44,6 +45,18 @@ namespace MockAsynchronousMethods.Repository.Tests
 
             Assert.NotNull(result);
             Assert.True(result.Any());
+        }
+
+        [Fact]
+        public async Task GivenAMockedDatabase_WhenDeletingAnArticleAsynchronously_ThenDeleteAsyncIsCalledOnce()
+        {
+            var mockArticleRepository = new FakeDbArticleMock()
+                .DeleteAsync();
+
+            var articleRepository = new ArticleRepository(mockArticleRepository.Object);
+            await articleRepository.DeleteArticleAsync(1);
+
+            mockArticleRepository.Verify(x => x.DeleteAsync(1), Times.Once);
         }
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/Mock/FakeDbArticleMock.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/Mock/FakeDbArticleMock.cs
@@ -3,6 +3,7 @@ using MockAsynchronousMethods.Repository.Interfaces;
 using MockAsynchronousMethods.Tests.Mock;
 using Moq;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace MockAsynchronousMethods.Repository.Tests.Mock
 {
@@ -28,6 +29,14 @@ namespace MockAsynchronousMethods.Repository.Tests.Mock
         {
             Setup(x => x.GetAsync())
                 .ReturnsAsync(FakeDb.Articles);
+
+            return this;
+        }
+
+        public FakeDbArticleMock DeleteAsync()
+        {
+            Setup(x => x.DeleteAsync(It.IsAny<int>()))
+                .Returns(Task.CompletedTask);
 
             return this;
         }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/MockAsynchronousMethods.Tests.csproj
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods.Tests/MockAsynchronousMethods.Tests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/ArticleRepository.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/ArticleRepository.cs
@@ -21,5 +21,10 @@ namespace MockAsynchronousMethods.Repository
         {
             return await _fakeDbArticle.GetAsync();
         }
+
+        public async Task DeleteArticleAsync(int id)
+        {
+            await _fakeDbArticle.DeleteAsync(id);
+        }
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/FakeDatabase/FakeDbArticles.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/FakeDatabase/FakeDbArticles.cs
@@ -43,5 +43,17 @@ namespace MockAsynchronousMethods.Repository.FakeDatabase
         {
             return await Task.FromResult(_articles.FirstOrDefault(x => x.Id == id));
         }
+
+        public async Task DeleteAsync(int id)
+        {
+            var article = _articles.FirstOrDefault(x => x.Id == id);
+
+            if (article is not null)
+            {
+                _articles.Remove(article);
+            }
+
+            await Task.CompletedTask;
+        }
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/Interfaces/IArticleRepository.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/Interfaces/IArticleRepository.cs
@@ -6,5 +6,6 @@ namespace MockAsynchronousMethods.Repository.Interfaces
     {
         Task<ArticleDbModel?> GetArticleAsync(int id);
         Task<IEnumerable<ArticleDbModel>> GetAllArticlesAsync();
+        Task DeleteArticleAsync(int id);
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/Interfaces/IFakeDbArticles.cs
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/Interfaces/IFakeDbArticles.cs
@@ -6,5 +6,6 @@ namespace MockAsynchronousMethods.Repository.Interfaces
     {
         Task<IEnumerable<ArticleDbModel>> GetAsync();
         Task<ArticleDbModel?> GetByIdAsync(int id);
+        Task DeleteAsync(int id);
     }
 }

--- a/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/MockAsynchronousMethods.Repository.csproj
+++ b/dotnet-testing/MockAsynchronousMethods/MockAsynchronousMethods/MockAsynchronousMethods.Repository.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Retargets net6.0 to net10.0, bumps Moq/xUnit/test-sdk packages to current stable, and adds a plain-Task mock (DeleteAsync) plus a Verify() assertion to the existing test class, matching the article rewrite.