### PR TITLE
DifferenceBetweenAwaitAndTaskWaitInCsharp: retarget net10.0, add Task.WhenAll/WhenAny/Delay example

### DIFF
--- a/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/CodeExamples.cs
+++ b/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/CodeExamples.cs
@@ -76,4 +76,42 @@ public static class CodeExamples
             Console.WriteLine(ex.Message);
         }
     }
+
+    public async static Task NonBlockingWaitExamplesAsync()
+    {
+        Console.WriteLine("** Non-Blocking Wait Examples **");
+
+        Task<string> singleTask = Task<string>.Run(() =>
+        {
+            Thread.Sleep(10);
+
+            return "Hello, from a single awaited task";
+        });
+
+        string singleResult = await singleTask;
+        Console.WriteLine(singleResult);
+
+        Task<string> firstTask = Task<string>.Run(() =>
+        {
+            Thread.Sleep(10);
+
+            return "Hello, from the first task";
+        });
+
+        Task<string> secondTask = Task<string>.Run(() =>
+        {
+            Thread.Sleep(20);
+
+            return "Hello, from the second task";
+        });
+
+        string[] allResults = await Task.WhenAll(firstTask, secondTask);
+        Console.WriteLine($"Both tasks finished: {string.Join(", ", allResults)}");
+
+        Task<string> firstToFinish = await Task.WhenAny(firstTask, secondTask);
+        Console.WriteLine($"First task to finish: {firstToFinish.Result}");
+
+        await Task.Delay(10);
+        Console.WriteLine("Waited 10ms without blocking the thread");
+    }
 }

--- a/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/DifferenceBetweenAwaitAndTaskWaitInCsharp.csproj
+++ b/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/DifferenceBetweenAwaitAndTaskWaitInCsharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/Program.cs
+++ b/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/Program.cs
@@ -3,5 +3,7 @@
 CodeExamples.BlockingCodeExample();
 await CodeExamples.AsynchronousCodeExampleAsync();
 
+await CodeExamples.NonBlockingWaitExamplesAsync();
+
 await CodeExamples.AsynchronousExceptionHandlingAsync();
 CodeExamples.BlockingExceptionHandling();

--- a/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/Tests/Tests.csproj
+++ b/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/Tests/UnitTests.cs
+++ b/async-csharp/DifferenceBetweenAwaitAndTaskWaitInCsharp/Tests/UnitTests.cs
@@ -6,9 +6,8 @@ namespace Tests;
 public class UnitTests
 {
     [TestMethod]
-    [ExpectedException(typeof(AggregateException))]
     public void GivenAFailingTask_WhenTaskWaitIsCalled_ThenAggregateExceptionIsRaised()
     {
-        CodeExamples.BlockingExceptionHandling();
+        Assert.ThrowsExactly<AggregateException>(() => CodeExamples.BlockingExceptionHandling());
     }
 }


### PR DESCRIPTION
Retargets the await-vs-Task.Wait sample to net10.0 (MSTest 4.3.3). Adds a NonBlockingWaitExamplesAsync method demonstrating await, Task.WhenAll, Task.WhenAny and Task.Delay, matching the new "How Do We Wait for a Task in C# Without Blocking?" section in the SEO rewrite of csharp-difference-between-await-and-task-wait. UnitTests.cs updated: MSTest 4.x removed ExpectedExceptionAttribute, switched to Assert.ThrowsExactly.