### PR TITLE
FloatingPointTypes: retarget net10.0, add float/double/decimal equality example

### DIFF
--- a/numbers-csharp/FloatingPointTypes/FloatingPointTypes/FloatingPointTypes.csproj
+++ b/numbers-csharp/FloatingPointTypes/FloatingPointTypes/FloatingPointTypes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/numbers-csharp/FloatingPointTypes/FloatingPointTypes/Program.cs
+++ b/numbers-csharp/FloatingPointTypes/FloatingPointTypes/Program.cs
@@ -7,3 +7,9 @@ var floatingArithmetic = new FloatingPointArithmetic();
 floatingArithmetic.FloatSumAndMultiplication(0.1f, 0.5f, 10);
 floatingArithmetic.DoubleSumAndMultiplication(0.2D, 1.5D, 10);
 floatingArithmetic.DecimalSumAndMultiplication(0.2M, 1.5M, 10);
+
+// Why 0.1 + 0.2 does not equal 0.3: double is base-two and rounds each value,
+// while decimal is base-ten and stores 0.1 exactly.
+Console.WriteLine(0.1 + 0.2 == 0.3);           // False
+Console.WriteLine((0.1 + 0.2).ToString("R"));  // 0.30000000000000004
+Console.WriteLine(0.1m + 0.2m == 0.3m);        // True

--- a/numbers-csharp/FloatingPointTypes/Tests/Tests.csproj
+++ b/numbers-csharp/FloatingPointTypes/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Retargets the FloatingPointTypes sample and its Tests project to net10.0 (test stack bumped to match the current batch: xunit 2.9.3, Microsoft.NET.Test.Sdk 17.8.0, coverlet 6.0.0, runner 3.0.0) and adds a short demonstration that `0.1 + 0.2 == 0.3` is False for double (with the round-trip value) but True for decimal. Build clean, 6/6 tests pass on net10.0.