### PR TITLE
DictionaryVsHashTablesSolution: retarget net10.0, bump BenchmarkDotNet and test packages

### DIFF
--- a/collections-dictionary/DictionaryVsHashTablesSolution/DictionaryVsHashTables/DictionaryVsHashTables.csproj
+++ b/collections-dictionary/DictionaryVsHashTablesSolution/DictionaryVsHashTables/DictionaryVsHashTables.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
 </Project>

--- a/collections-dictionary/DictionaryVsHashTablesSolution/Tests/Tests.csproj
+++ b/collections-dictionary/DictionaryVsHashTablesSolution/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Retargets collections-dictionary/DictionaryVsHashTablesSolution to net10.0 (BenchmarkDotNet 0.15.8, MSTest 4.3.3, Microsoft.NET.Test.Sdk 18.9.0, coverlet.collector 10.0.1). No source changes -- build 0 errors/0 warnings, 9/9 tests pass. Benchmark figures re-run on .NET 10 for the article update.