### PR TITLE
YamlDotNet: retarget net10.0, bump to 18.1.0, add naming-convention example

### DIFF
--- a/dotnet-client-libraries/YamlDotNet/App/App.csproj
+++ b/dotnet-client-libraries/YamlDotNet/App/App.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="YamlDotNet" Version="15.1.2"/>
+        <PackageReference Include="YamlDotNet" Version="18.1.0"/>
     </ItemGroup>
 
 </Project>

--- a/dotnet-client-libraries/YamlDotNet/App/Models/ServiceConfig.cs
+++ b/dotnet-client-libraries/YamlDotNet/App/Models/ServiceConfig.cs
@@ -1,0 +1,7 @@
+namespace App.Models;
+
+public class ServiceConfig
+{
+    public required string ServiceName { get; set; }
+    public int MaxRetries { get; set; }
+}

--- a/dotnet-client-libraries/YamlDotNet/App/Program.cs
+++ b/dotnet-client-libraries/YamlDotNet/App/Program.cs
@@ -2,6 +2,7 @@
 using App.UseCases;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.Serialization.NodeDeserializers;
 
 namespace App;
@@ -79,6 +80,15 @@ public class Program
         {
             Console.WriteLine($"Unable to deserialize person: {e.Message}");
         }
+
+        // Map YAML Names to C# Property Names
+
+        var config = new ServiceConfig { ServiceName = "orders", MaxRetries = 3 };
+        var hyphenatedYaml = NamingConventions.Serialize(config, HyphenatedNamingConvention.Instance);
+        Console.WriteLine(hyphenatedYaml);
+
+        var deserializeConfig = NamingConventions.Deserialize<ServiceConfig>(hyphenatedYaml, HyphenatedNamingConvention.Instance);
+        Console.WriteLine($"ServiceName: {deserializeConfig.ServiceName}, MaxRetries: {deserializeConfig.MaxRetries}");
 
         // JSON Support in YamlDotNet
 

--- a/dotnet-client-libraries/YamlDotNet/App/UseCases/DeserializerValidation.cs
+++ b/dotnet-client-libraries/YamlDotNet/App/UseCases/DeserializerValidation.cs
@@ -8,9 +8,9 @@ namespace App.UseCases;
 public class DeserializerValidation(INodeDeserializer nodeDeserializer) : INodeDeserializer
 {
     public bool Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer,
-        out object? value)
+        out object? value, ObjectDeserializer rootDeserializer)
     {
-        if (!nodeDeserializer.Deserialize(reader, expectedType, nestedObjectDeserializer, out value))
+        if (!nodeDeserializer.Deserialize(reader, expectedType, nestedObjectDeserializer, out value, rootDeserializer))
             return false;
 
         var context = new ValidationContext(value);

--- a/dotnet-client-libraries/YamlDotNet/App/UseCases/NamingConventions.cs
+++ b/dotnet-client-libraries/YamlDotNet/App/UseCases/NamingConventions.cs
@@ -1,0 +1,24 @@
+using YamlDotNet.Serialization;
+
+namespace App.UseCases;
+
+public static class NamingConventions
+{
+    public static string Serialize<T>(T obj, INamingConvention namingConvention)
+    {
+        var serializer = new SerializerBuilder()
+            .WithNamingConvention(namingConvention)
+            .Build();
+
+        return serializer.Serialize(obj);
+    }
+
+    public static T Deserialize<T>(string yaml, INamingConvention namingConvention)
+    {
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(namingConvention)
+            .Build();
+
+        return deserializer.Deserialize<T>(yaml);
+    }
+}

--- a/dotnet-client-libraries/YamlDotNet/Tests/NamingConventionsTests.cs
+++ b/dotnet-client-libraries/YamlDotNet/Tests/NamingConventionsTests.cs
@@ -1,0 +1,29 @@
+using App.Models;
+using App.UseCases;
+using static System.Environment;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Tests;
+
+public class NamingConventionsTests
+{
+    [Fact]
+    public void GivenConfig_WhenSerializedWithHyphenatedConvention_ThenKeysAreHyphenated()
+    {
+        var config = new ServiceConfig { ServiceName = "orders", MaxRetries = 3 };
+        var expectedYaml = $"service-name: orders{NewLine}max-retries: 3{NewLine}";
+        var actualYaml = NamingConventions.Serialize(config, HyphenatedNamingConvention.Instance);
+
+        Assert.Equal(expectedYaml, actualYaml);
+    }
+
+    [Fact]
+    public void GivenHyphenatedYaml_WhenDeserializedWithHyphenatedConvention_ThenConfigIsReturned()
+    {
+        var yaml = $"service-name: orders{NewLine}max-retries: 3";
+        var actualConfig = NamingConventions.Deserialize<ServiceConfig>(yaml, HyphenatedNamingConvention.Instance);
+
+        Assert.Equal("orders", actualConfig.ServiceName);
+        Assert.Equal(3, actualConfig.MaxRetries);
+    }
+}

--- a/dotnet-client-libraries/YamlDotNet/Tests/Tests.csproj
+++ b/dotnet-client-libraries/YamlDotNet/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -10,10 +10,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="coverlet.collector" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Retargets the YamlDotNet sample to net10.0 and bumps YamlDotNet 15.1.2 -> 18.1.0. The 18.x `INodeDeserializer.Deserialize` gained an `ObjectDeserializer rootDeserializer` parameter, so `DeserializerValidation` is updated to the new signature. Adds a `NamingConventions` use case (hyphenated round-trip) with a `ServiceConfig` model and tests. Build + 9 tests green on net10.0.