### PR TITLE
IntroductionToScrutorInDotNet: retarget net10.0, bump Scrutor to 7.0.0, add pitfalls tests

### DIFF
--- a/dependency-injection-tools/IntroductionToScrutorInDotNet/IntroductionToScrutorInDotNet.Customers/IntroductionToScrutorInDotNet.Customers.csproj
+++ b/dependency-injection-tools/IntroductionToScrutorInDotNet/IntroductionToScrutorInDotNet.Customers/IntroductionToScrutorInDotNet.Customers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/dependency-injection-tools/IntroductionToScrutorInDotNet/IntroductionToScrutorInDotNet/IntroductionToScrutorInDotNet.csproj
+++ b/dependency-injection-tools/IntroductionToScrutorInDotNet/IntroductionToScrutorInDotNet/IntroductionToScrutorInDotNet.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.7" />
-    <PackageReference Include="Scrutor" Version="4.2.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dependency-injection-tools/IntroductionToScrutorInDotNet/IntroductionToScrutorInDotNet/Program.cs
+++ b/dependency-injection-tools/IntroductionToScrutorInDotNet/IntroductionToScrutorInDotNet/Program.cs
@@ -7,7 +7,7 @@ using Scrutor;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.Scan(selector => selector
-    .FromCallingAssembly()
+    .FromAssembliesOf(typeof(Program))
     .AddClasses(
         classSelector =>
             classSelector.InNamespaces("IntroductionToScrutorInDotNet.Services.Implementations")
@@ -24,7 +24,7 @@ builder.Services.Scan(selector => selector
 );
 
 builder.Services.Scan(selector => selector
-    .FromCallingAssembly()
+    .FromAssembliesOf(typeof(Program))
     .AddClasses(classSelector => classSelector.AssignableTo(typeof(IRepository<>)))
     .UsingRegistrationStrategy(RegistrationStrategy.Skip)
     .AsImplementedInterfaces());

--- a/dependency-injection-tools/IntroductionToScrutorInDotNet/Tests/ScrutorPitfallsTests.cs
+++ b/dependency-injection-tools/IntroductionToScrutorInDotNet/Tests/ScrutorPitfallsTests.cs
@@ -1,0 +1,85 @@
+using IntroductionToScrutorInDotNet.Entities;
+using IntroductionToScrutorInDotNet.Repositories;
+using IntroductionToScrutorInDotNet.Repositories.Decorators;
+using IntroductionToScrutorInDotNet.Repositories.Implementations;
+using Microsoft.Extensions.DependencyInjection;
+using Scrutor;
+
+namespace Tests;
+
+public class ScrutorPitfallsTests
+{
+    private static ServiceCollection ScanRepositories(RegistrationStrategy? strategy = null)
+    {
+        var services = new ServiceCollection();
+        services.Scan(selector => selector
+            .FromAssembliesOf(typeof(UserRepository))
+            .AddClasses(classSelector => classSelector.AssignableTo(typeof(IRepository<>)))
+            .UsingRegistrationStrategy(strategy ?? RegistrationStrategy.Append)
+            .AsImplementedInterfaces());
+        return services;
+    }
+
+    [Fact]
+    public void GivenTwoScans_WhenAppending_ThenRegistrationIsDuplicated()
+    {
+        var services = ScanRepositories();
+        services.Scan(selector => selector
+            .FromAssembliesOf(typeof(UserRepository))
+            .AddClasses(classSelector => classSelector.AssignableTo(typeof(IRepository<>)))
+            .AsImplementedInterfaces());
+
+        var count = services.Count(descriptor => descriptor.ServiceType == typeof(IRepository<User>));
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void GivenTwoScans_WhenUsingSkipStrategy_ThenRegistrationIsNotDuplicated()
+    {
+        var services = ScanRepositories(RegistrationStrategy.Skip);
+        services.Scan(selector => selector
+            .FromAssembliesOf(typeof(UserRepository))
+            .AddClasses(classSelector => classSelector.AssignableTo(typeof(IRepository<>)))
+            .UsingRegistrationStrategy(RegistrationStrategy.Skip)
+            .AsImplementedInterfaces());
+
+        var count = services.Count(descriptor => descriptor.ServiceType == typeof(IRepository<User>));
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void GivenScannedRegistration_WhenLifetimeIsNotSpecified_ThenItIsTransient()
+    {
+        var services = ScanRepositories();
+
+        var descriptor = services.First(d => d.ServiceType == typeof(IRepository<User>));
+
+        Assert.Equal(ServiceLifetime.Transient, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void GivenNoPriorRegistration_WhenDecorating_ThenDecorationExceptionIsThrown()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<DecorationException>(() =>
+            services.Decorate<IRepository<User>, RepositoryLoggerDecorator<User>>());
+
+        Assert.Contains("Could not find any registered services", exception.Message);
+    }
+
+    [Fact]
+    public void GivenScannedRepository_WhenDecoratingTheOpenGeneric_ThenTheDecoratorResolves()
+    {
+        var services = ScanRepositories();
+
+        services.Decorate(typeof(IRepository<>), typeof(RepositoryLoggerDecorator<>));
+
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredService<IRepository<User>>();
+
+        Assert.IsType<RepositoryLoggerDecorator<User>>(resolved);
+    }
+}

--- a/dependency-injection-tools/IntroductionToScrutorInDotNet/Tests/Tests.csproj
+++ b/dependency-injection-tools/IntroductionToScrutorInDotNet/Tests/Tests.csproj
@@ -1,22 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Retargets the Scrutor sample to net10.0 and bumps packages to current versions (Scrutor 7.0.0, ASP.NET Core 10.0.11 test/OpenApi, Swashbuckle 10.2.3, xunit 2.9.3, Test.Sdk 18.9.0, coverlet 10.0.1).

Scrutor 7.0.0 removed `FromCallingAssembly()`, so both scans in `Program.cs` now use `FromAssembliesOf(typeof(Program))`.

Adds `ScrutorPitfallsTests` covering the behaviors the article documents: duplicate-scan append, `RegistrationStrategy.Skip` dedup, default transient lifetime, `DecorationException` when decorating an unregistered service, and open-generic decoration of the scanned repository.

Build -c Release and `dotnet test` are green on net10.0 (8 tests).