### PR TITLE
AutomapperVsMapster: update to .NET 10 and current library versions

### DIFF
--- a/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster.Benchmark/AutomapperVsMapster.Benchmark.csproj
+++ b/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster.Benchmark/AutomapperVsMapster.Benchmark.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/AttributeMapping/AutoMapper/AutoMapperAttributeMapping.cs
+++ b/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/AttributeMapping/AutoMapper/AutoMapperAttributeMapping.cs
@@ -1,9 +1,10 @@
 ﻿using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AutomapperVsMapster.AttributeMapping.AutoMapper;
 public class AutoMapperAttributeMapping
 {
-    public static IMapper Mapper = new MapperConfiguration(cfg => cfg.AddMaps(typeof(AutoMapperAttributeMapping).Assembly)).CreateMapper();
+    public static IMapper Mapper = new MapperConfiguration(cfg => cfg.AddMaps(typeof(AutoMapperAttributeMapping).Assembly), NullLoggerFactory.Instance).CreateMapper();
 
     public static UserDto Map(User source)
     {

--- a/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/AutomapperVsMapster.csproj
+++ b/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/AutomapperVsMapster.csproj
@@ -1,16 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="Mapster" Version="7.3.0" />
+    <PackageReference Include="AutoMapper" Version="16.2.0" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
+    <PackageReference Include="Mapster" Version="10.0.11" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/CollectionMapping/AutoMapperCollectionMapping.cs
+++ b/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/CollectionMapping/AutoMapperCollectionMapping.cs
@@ -1,9 +1,10 @@
 ﻿using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AutomapperVsMapster.CollectionMapping;
 public class AutoMapperCollectionMapping
 {
-    public static IMapper Mapper = new MapperConfiguration(cfg => cfg.CreateMap<User, UserDto>()).CreateMapper();
+    public static IMapper Mapper = new MapperConfiguration(cfg => cfg.CreateMap<User, UserDto>(), NullLoggerFactory.Instance).CreateMapper();
 
     public static List<UserDto> Map(List<User> source)
     {

--- a/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/CustomPropertyMapping/AutoMapperCustomPropertyMapping.cs
+++ b/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/CustomPropertyMapping/AutoMapperCustomPropertyMapping.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AutomapperVsMapster.CustomPropertyMapping;
 public class AutoMapperCustomPropertyMapping
@@ -10,7 +11,7 @@ public class AutoMapperCustomPropertyMapping
                 dest => dest.FullName,
                 config => config.MapFrom(src => $"{src.FirstName} {src.LastName}"
             ));
-        })
+        }, NullLoggerFactory.Instance)
         .CreateMapper();
 
     public static UserDto Map(User source)

--- a/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/Flattened/AutoMapperFlattenedMapping.cs
+++ b/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/Flattened/AutoMapperFlattenedMapping.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AutomapperVsMapster.Flattened;
 public class AutoMapperFlattenedMapping
@@ -6,7 +7,7 @@ public class AutoMapperFlattenedMapping
     public static IMapper Mapper = new MapperConfiguration(cfg =>
         {
             cfg.CreateMap<User, UserDto>();
-        })
+        }, NullLoggerFactory.Instance)
         .CreateMapper();
 
     public static UserDto Map(User source)

--- a/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/NestedTypeMapping/AutoMapperNestedTypeMapping.cs
+++ b/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/NestedTypeMapping/AutoMapperNestedTypeMapping.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AutomapperVsMapster.NestedTypeMapping;
 public class AutoMapperNestedTypeMapping
@@ -7,7 +8,7 @@ public class AutoMapperNestedTypeMapping
         {
             cfg.CreateMap<User, UserDto>();
             cfg.CreateMap<Address, AddressDto>();
-        })
+        }, NullLoggerFactory.Instance)
         .CreateMapper();
 
     public static UserDto Map(User source)

--- a/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/ReverseMappingAndUnflattening/AutoMapperReverseMapping.cs
+++ b/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/ReverseMappingAndUnflattening/AutoMapperReverseMapping.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AutomapperVsMapster.ReverseMappingAndUnflattening;
 public class AutoMapperReverseMapping
@@ -8,7 +9,7 @@ public class AutoMapperReverseMapping
             cfg.CreateMap<User, UserDto>()
                 .ForMember(dest => dest.EmailAddress, config => config.MapFrom(src => src.Email))
                 .ReverseMap();
-        })
+        }, NullLoggerFactory.Instance)
         .CreateMapper();
 
     public static User Map(UserDto destination)

--- a/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/SimpleTypeMapping/AutoMapperSimpleTypeMapping.cs
+++ b/dotnet-client-libraries/AutomapperVsMapster/AutomapperVsMapster/SimpleTypeMapping/AutoMapperSimpleTypeMapping.cs
@@ -1,9 +1,10 @@
 ﻿using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AutomapperVsMapster.SimpleTypeMapping;
 public class AutoMapperSimpleTypeMapping
 {
-    public static IMapper Mapper = new MapperConfiguration(cfg => cfg.CreateMap<User, UserDto>()).CreateMapper();
+    public static IMapper Mapper = new MapperConfiguration(cfg => cfg.CreateMap<User, UserDto>(), NullLoggerFactory.Instance).CreateMapper();
 
     public static UserDto Map(User source)
     {

--- a/dotnet-client-libraries/AutomapperVsMapster/Tests/Tests.csproj
+++ b/dotnet-client-libraries/AutomapperVsMapster/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Updates the `dotnet-client-libraries/AutomapperVsMapster` sample for the refreshed *AutoMapper vs Mapster* article.

- Retarget all three projects to `net10.0`.
- Bump packages to current stable: AutoMapper 16.2.0, Mapster 10.0.11, BenchmarkDotNet 0.15.8, Bogus 35.6.5, and the xunit/test SDK stack.
- AutoMapper 15+ changed the `MapperConfiguration` constructor to require an `ILoggerFactory`; the standalone mapping examples now pass `NullLoggerFactory.Instance`.

`dotnet build -c Release`, `dotnet test` (14 passed) and the BenchmarkDotNet suite are green on net10.0.