### PR TITLE
Add CQRS and MediatR in ASP.NET Core sample

### DIFF
--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore.sln
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore.sln
@@ -1,0 +1,53 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CqrsAndMediatRInAspNetCore", "CqrsAndMediatRInAspNetCore\CqrsAndMediatRInAspNetCore.csproj", "{A35A7661-54DB-466D-BFB1-F743CB102862}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CqrsAndMediatRInAspNetCoreTests", "Tests\CqrsAndMediatRInAspNetCoreTests\CqrsAndMediatRInAspNetCoreTests.csproj", "{1AAD829F-350B-49F1-B9CC-9451038A08CF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Debug|x64.Build.0 = Debug|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Debug|x86.Build.0 = Debug|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Release|x64.ActiveCfg = Release|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Release|x64.Build.0 = Release|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Release|x86.ActiveCfg = Release|Any CPU
+		{A35A7661-54DB-466D-BFB1-F743CB102862}.Release|x86.Build.0 = Release|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Debug|x64.Build.0 = Debug|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Debug|x86.Build.0 = Debug|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Release|x64.ActiveCfg = Release|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Release|x64.Build.0 = Release|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Release|x86.ActiveCfg = Release|Any CPU
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1AAD829F-350B-49F1-B9CC-9451038A08CF} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+	EndGlobalSection
+EndGlobal

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Behaviors/LoggingBehavior.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Behaviors/LoggingBehavior.cs
@@ -1,0 +1,25 @@
+﻿using MediatR;
+
+namespace CqrsAndMediatRInAspNetCore.Behaviors
+{
+	public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+		where TRequest : IRequest<TResponse>
+	{
+		private readonly ILogger<LoggingBehavior<TRequest, TResponse>> _logger;
+
+		public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger)
+			=> _logger = logger;
+
+		public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next,
+			CancellationToken cancellationToken) 
+		{
+			_logger.LogInformation($"Handling {typeof(TRequest).Name}"); 
+
+			var response = await next(); 
+			
+			_logger.LogInformation($"Handled {typeof(TResponse).Name}"); 
+			
+			return response;
+		}
+	}
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Commands/AddProductCommand.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Commands/AddProductCommand.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+
+namespace CqrsAndMediatRInAspNetCore.Commands
+{
+	public record AddProductCommand(Product Product) : IRequest<Product>;
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Controllers/ProductsController.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Controllers/ProductsController.cs
@@ -1,0 +1,43 @@
+﻿using CqrsAndMediatRInAspNetCore.Commands;
+using CqrsAndMediatRInAspNetCore.Notifications;
+using CqrsAndMediatRInAspNetCore.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CqrsAndMediatRInAspNetCore.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ProductsController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public ProductsController(IMediator mediator) => _mediator = mediator;
+
+        [HttpGet]
+        public async Task<ActionResult> GetProducts()
+        {
+            var products = await _mediator.Send(new GetProductsQuery());
+
+            return Ok(products);
+        }
+
+        [HttpGet("{id:int}", Name = "GetProductById")]
+        public async Task<ActionResult> GetProductById(int id)
+        {
+            var product = await _mediator.Send(new GetProductByIdQuery(id));
+
+            return Ok(product);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult> AddProduct([FromBody] Product product)
+        {
+            var productToReturn = await _mediator.Send(new AddProductCommand(product)); 
+            
+            await _mediator.Publish(new ProductAddedNotification(productToReturn)); 
+
+            return CreatedAtRoute("GetProductById", new { id = productToReturn.Id }, productToReturn);
+        }
+    }
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore.csproj
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/DataStore/FakeDataStore.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/DataStore/FakeDataStore.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CqrsAndMediatRInAspNetCore.DataStore
+{
+	public class FakeDataStore
+	{
+		private static List<Product> _products;
+
+		public FakeDataStore()
+		{
+			_products = new List<Product>
+			{
+				new Product { Id = 1, Name = "Test Product 1" },
+				new Product { Id = 2, Name = "Test Product 2" },
+				new Product { Id = 3, Name = "Test Product 3" }
+			};
+		}
+
+		public async Task AddProduct(Product product)
+		{ 
+			_products.Add(product);
+			await Task.CompletedTask;
+		}
+
+		public async Task<IEnumerable<Product>> GetAllProducts() => await Task.FromResult(_products);
+
+		public async Task<Product> GetProductById(int id) =>
+			await Task.FromResult(_products.Single(p => p.Id == id));
+
+		public async Task EventOccured(Product product, string evt)
+		{
+			_products.Single(p => p.Id == product.Id).Name = $"{product.Name} evt: {evt}";
+			await Task.CompletedTask;
+		}
+	}
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/AddProductHandler.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/AddProductHandler.cs
@@ -1,0 +1,20 @@
+﻿using CqrsAndMediatRInAspNetCore.Commands;
+using CqrsAndMediatRInAspNetCore.DataStore;
+using MediatR;
+
+namespace CqrsAndMediatRInAspNetCore.Handlers
+{
+    public class AddProductHandler : IRequestHandler<AddProductCommand, Product> 
+    { 
+        private readonly FakeDataStore _fakeDataStore; 
+        
+        public AddProductHandler(FakeDataStore fakeDataStore) => _fakeDataStore = fakeDataStore; 
+        
+        public async Task<Product> Handle(AddProductCommand request, CancellationToken cancellationToken) 
+        {
+            await _fakeDataStore.AddProduct(request.Product); 
+            
+            return request.Product; 
+        } 
+    }
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/CacheInvalidationHandler.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/CacheInvalidationHandler.cs
@@ -1,0 +1,24 @@
+﻿using CqrsAndMediatRInAspNetCore.DataStore;
+using CqrsAndMediatRInAspNetCore.Notifications;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CqrsAndMediatRInAspNetCore.Handlers
+{
+	public class CacheInvalidationHandler : INotificationHandler<ProductAddedNotification>
+	{
+		private readonly FakeDataStore _fakeDataStore;
+
+		public CacheInvalidationHandler(FakeDataStore fakeDataStore) => _fakeDataStore = fakeDataStore;
+
+		public async Task Handle(ProductAddedNotification notification, CancellationToken cancellationToken)
+		{
+			await _fakeDataStore.EventOccured(notification.Product, "Cache Invalidated");
+			await Task.CompletedTask;
+		}
+	}
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/EmailHandler.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/EmailHandler.cs
@@ -1,0 +1,24 @@
+﻿using CqrsAndMediatRInAspNetCore.DataStore;
+using CqrsAndMediatRInAspNetCore.Notifications;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CqrsAndMediatRInAspNetCore.Handlers
+{
+	public class EmailHandler : INotificationHandler<ProductAddedNotification>
+	{
+		private readonly FakeDataStore _fakeDataStore;
+
+		public EmailHandler(FakeDataStore fakeDataStore) => _fakeDataStore = fakeDataStore;
+
+		public async Task Handle(ProductAddedNotification notification, CancellationToken cancellationToken)
+		{
+			await _fakeDataStore.EventOccured(notification.Product, "Email sent");
+			await Task.CompletedTask;
+		}
+	}
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/GetProductByIdHandler.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/GetProductByIdHandler.cs
@@ -1,0 +1,17 @@
+﻿using CqrsAndMediatRInAspNetCore.DataStore;
+using CqrsAndMediatRInAspNetCore.Queries;
+using MediatR;
+
+namespace CqrsAndMediatRInAspNetCore.Handlers
+{
+    public class GetProductByIdHandler : IRequestHandler<GetProductByIdQuery, Product>
+	{
+		private readonly FakeDataStore _fakeDataStore;
+
+		public GetProductByIdHandler(FakeDataStore fakeDataStore) => _fakeDataStore = fakeDataStore;
+
+		public async Task<Product> Handle(GetProductByIdQuery request, CancellationToken cancellationToken) =>
+			await _fakeDataStore.GetProductById(request.Id);
+		
+	}
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/GetProductsHandler.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Handlers/GetProductsHandler.cs
@@ -1,0 +1,16 @@
+﻿using CqrsAndMediatRInAspNetCore.DataStore;
+using CqrsAndMediatRInAspNetCore.Queries;
+using MediatR;
+
+namespace CqrsAndMediatRInAspNetCore.Handlers
+{
+    public class GetProductsHandler : IRequestHandler<GetProductsQuery, IEnumerable<Product>>
+	{
+		private readonly FakeDataStore _fakeDataStore;
+
+		public GetProductsHandler(FakeDataStore fakeDataStore) => _fakeDataStore = fakeDataStore;
+
+		public async Task<IEnumerable<Product>> Handle(GetProductsQuery request,
+			CancellationToken cancellationToken) => await _fakeDataStore.GetAllProducts();
+	}
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Notifications/ProductAddedNotification.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Notifications/ProductAddedNotification.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+
+namespace CqrsAndMediatRInAspNetCore.Notifications
+{
+	public record ProductAddedNotification(Product Product) : INotification;
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Product.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Product.cs
@@ -1,0 +1,8 @@
+﻿namespace CqrsAndMediatRInAspNetCore
+{
+    public class Product
+	{
+		public int Id { get; set; }
+		public string? Name { get; set; }
+	}
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Program.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Program.cs
@@ -1,0 +1,25 @@
+using CqrsAndMediatRInAspNetCore.Behaviors;
+using CqrsAndMediatRInAspNetCore.DataStore;
+using MediatR;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Program).Assembly));
+
+builder.Services.AddSingleton<FakeDataStore>();
+
+builder.Services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Properties/launchSettings.json
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+﻿{
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Queries/GetProductByIdQuery.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Queries/GetProductByIdQuery.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+
+namespace CqrsAndMediatRInAspNetCore.Queries
+{
+    public record GetProductByIdQuery(int Id) : IRequest<Product>;
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Queries/GetProductsQuery.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/Queries/GetProductsQuery.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+
+namespace CqrsAndMediatRInAspNetCore.Queries
+{
+    public record GetProductsQuery() : IRequest<IEnumerable<Product>>;
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/appsettings.Development.json
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/appsettings.json
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/CqrsAndMediatRInAspNetCore/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/Tests/CqrsAndMediatRInAspNetCoreTests/CqrsAndMediatRInAspNetCoreTests.csproj
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/Tests/CqrsAndMediatRInAspNetCoreTests/CqrsAndMediatRInAspNetCoreTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\CqrsAndMediatRInAspNetCore\CqrsAndMediatRInAspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/Tests/CqrsAndMediatRInAspNetCoreTests/LoggingBehaviorTests.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/Tests/CqrsAndMediatRInAspNetCoreTests/LoggingBehaviorTests.cs
@@ -1,0 +1,32 @@
+using CqrsAndMediatRInAspNetCore;
+using CqrsAndMediatRInAspNetCore.Behaviors;
+using CqrsAndMediatRInAspNetCore.Queries;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace CqrsAndMediatRInAspNetCoreTests;
+
+public class LoggingBehaviorTests
+{
+    [Fact]
+    public async Task WhenHandle_ThenPassesResponseThroughAndLogsBeforeAndAfter()
+    {
+        var loggerMock = new Mock<ILogger<LoggingBehavior<GetProductsQuery, IEnumerable<Product>>>>();
+        var behavior = new LoggingBehavior<GetProductsQuery, IEnumerable<Product>>(loggerMock.Object);
+        var expected = new List<Product> { new() { Id = 1, Name = "Test Product 1" } };
+        RequestHandlerDelegate<IEnumerable<Product>> next = _ => Task.FromResult<IEnumerable<Product>>(expected);
+
+        var result = await behavior.Handle(new GetProductsQuery(), next, CancellationToken.None);
+
+        Assert.Same(expected, result);
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Exactly(2));
+    }
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/Tests/CqrsAndMediatRInAspNetCoreTests/ProductHandlersTests.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/Tests/CqrsAndMediatRInAspNetCoreTests/ProductHandlersTests.cs
@@ -1,0 +1,74 @@
+using CqrsAndMediatRInAspNetCore;
+using CqrsAndMediatRInAspNetCore.Commands;
+using CqrsAndMediatRInAspNetCore.DataStore;
+using CqrsAndMediatRInAspNetCore.Handlers;
+using CqrsAndMediatRInAspNetCore.Notifications;
+using CqrsAndMediatRInAspNetCore.Queries;
+
+namespace CqrsAndMediatRInAspNetCoreTests;
+
+public class ProductHandlersTests
+{
+    private static FakeDataStore NewSeededStore() => new();
+
+    [Fact]
+    public async Task WhenHandleGetProductsQuery_ThenReturnsAllSeededProducts()
+    {
+        var handler = new GetProductsHandler(NewSeededStore());
+
+        var result = await handler.Handle(new GetProductsQuery(), CancellationToken.None);
+
+        Assert.Equal(3, result.Count());
+    }
+
+    [Fact]
+    public async Task WhenHandleGetProductByIdQuery_ThenReturnsMatchingProduct()
+    {
+        var handler = new GetProductByIdHandler(NewSeededStore());
+
+        var result = await handler.Handle(new GetProductByIdQuery(2), CancellationToken.None);
+
+        Assert.Equal(2, result.Id);
+        Assert.Equal("Test Product 2", result.Name);
+    }
+
+    [Fact]
+    public async Task WhenHandleAddProductCommand_ThenProductIsPersistedAndReturned()
+    {
+        var store = NewSeededStore();
+        var addHandler = new AddProductHandler(store);
+        var newProduct = new Product { Id = 4, Name = "Test Product 4" };
+
+        var returned = await addHandler.Handle(new AddProductCommand(newProduct), CancellationToken.None);
+
+        Assert.Equal(newProduct, returned);
+        var all = await new GetProductsHandler(store).Handle(new GetProductsQuery(), CancellationToken.None);
+        Assert.Contains(all, p => p.Id == 4 && p.Name == "Test Product 4");
+    }
+
+    [Fact]
+    public async Task WhenEmailHandlerHandlesNotification_ThenProductRecordsTheEvent()
+    {
+        var store = NewSeededStore();
+        var handler = new EmailHandler(store);
+        var product = new Product { Id = 1, Name = "Test Product 1" };
+
+        await handler.Handle(new ProductAddedNotification(product), CancellationToken.None);
+
+        var stored = await store.GetProductById(1);
+        Assert.Equal("Test Product 1 evt: Email sent", stored.Name);
+    }
+
+    [Fact]
+    public async Task WhenCacheInvalidationHandlerHandlesNotification_ThenProductRecordsTheEvent()
+    {
+        var store = NewSeededStore();
+        var handler = new CacheInvalidationHandler(store);
+        var product = new Product { Id = 3, Name = "Test Product 3" };
+
+        await handler.Handle(new ProductAddedNotification(product), CancellationToken.None);
+
+        var stored = await store.GetProductById(3);
+        Assert.Equal("Test Product 3 evt: Cache Invalidated", stored.Name);
+    }
+}

--- a/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/Tests/CqrsAndMediatRInAspNetCoreTests/Usings.cs
+++ b/dotnet-client-libraries/CqrsAndMediatRInAspNetCore/Tests/CqrsAndMediatRInAspNetCoreTests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
Adds a runnable sample for the article **CQRS and MediatR in ASP.NET Core** (https://code-maze.com/cqrs-mediatr-in-aspnet-core/).

A Products API demonstrating CQRS with MediatR: queries, commands, notifications, and a logging pipeline behavior, plus an xUnit test project covering the handlers and the behavior.

- Targets `net10.0`
- Pins `MediatR` `12.5.0` (last Apache-2.0 release; v13+ is dual-licensed RPL-1.5/commercial)
- `dotnet build -c Release` and `dotnet test` green on net10.0 (6/6 tests pass)