### PR TITLE
Update HowToUseMapster sample to .NET 10 and fix age calculation

### DIFF
--- a/dotnet-client-libraries/HowToUseMapster/.config/dotnet-tools.json
+++ b/dotnet-client-libraries/HowToUseMapster/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "mapster.tool": {
-      "version": "8.3.0",
+      "version": "10.0.11",
       "commands": [
         "dotnet-mapster"
       ]

--- a/dotnet-client-libraries/HowToUseMapster/HowToUseMapster/Config/MapsterConfig.cs
+++ b/dotnet-client-libraries/HowToUseMapster/HowToUseMapster/Config/MapsterConfig.cs
@@ -13,7 +13,8 @@ namespace HowToUseMapster.Config
                 .NewConfig()
                 .Map(dest => dest.FullName, src => $"{src.Title} {src.FirstName} {src.LastName}")
                 .Map(dest => dest.Age,
-                     src => DateTime.Now.Year - src.DateOfBirth.Value.Year,
+                     src => CalculateAge(DateOnly.FromDateTime(src.DateOfBirth!.Value),
+                                         DateOnly.FromDateTime(DateTime.UtcNow)),
                      srcCond => srcCond.DateOfBirth.HasValue)
                 .Map(dest => dest.FullAddress, src => $"{src.Address.Street} {src.Address.PostCode} - {src.Address.City}");
 
@@ -27,6 +28,18 @@ namespace HowToUseMapster.Config
                 .AfterMapping((src, result) => result.SayGoodbye());
 
             TypeAdapterConfig.GlobalSettings.Scan(Assembly.GetExecutingAssembly());
+        }
+
+        public static int CalculateAge(DateOnly birthDate, DateOnly today)
+        {
+            var age = today.Year - birthDate.Year;
+
+            if (birthDate > today.AddYears(-age))
+            {
+                age--;
+            }
+
+            return age;
         }
     }
 }

--- a/dotnet-client-libraries/HowToUseMapster/HowToUseMapster/HowToUseMapster.csproj
+++ b/dotnet-client-libraries/HowToUseMapster/HowToUseMapster/HowToUseMapster.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mapster" Version="7.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Mapster" Version="10.0.11" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <Target Name="Mapster">

--- a/dotnet-client-libraries/HowToUseMapster/Tests/Tests.cs
+++ b/dotnet-client-libraries/HowToUseMapster/Tests/Tests.cs
@@ -1,5 +1,7 @@
 using HowToUseMapster;
+using HowToUseMapster.Config;
 using HowToUseMapster.Data;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -45,6 +47,28 @@ namespace Tests
 
             Assert.NotNull(entity);
             Assert.Equal(_person.FirstName, entity.FirstName);
+        }
+
+        [Fact]
+        public void GivenBirthdayAlreadyPassedThisYear_WhenCalculateAge_ThenReturnsFullYears()
+        {
+            var birthDate = new DateOnly(1990, 1, 1);
+            var today = new DateOnly(2026, 8, 15);
+
+            var age = MapsterConfig.CalculateAge(birthDate, today);
+
+            Assert.Equal(36, age);
+        }
+
+        [Fact]
+        public void GivenLeapDayBirthdayInNonLeapYear_WhenCalculateAgeBeforeMarch_ThenBirthdayNotYetCounted()
+        {
+            var birthDate = new DateOnly(2000, 2, 29);
+            var today = new DateOnly(2025, 2, 28);
+
+            var age = MapsterConfig.CalculateAge(birthDate, today);
+
+            Assert.Equal(24, age);
         }
     }
 }

--- a/dotnet-client-libraries/HowToUseMapster/Tests/Tests.csproj
+++ b/dotnet-client-libraries/HowToUseMapster/Tests/Tests.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Retargets the HowToUseMapster sample and its tests to net10.0 and bumps Mapster to 10.0.11 (with Mapster.Tool and Swashbuckle to current stable, plus refreshed test packages).

Replaces the naive `DateTime.Now.Year - DateOfBirth.Year` age rule with a leap-safe `CalculateAge()` helper built on `DateOnly`, which is off by a year before a person's birthday in the original. Adds two edge-case unit tests: a birthday already passed this year, and a 29 February birthday evaluated in a non-leap year.

Build and tests are green on net10.0 (6 tests passing). The Mapster code-generation tool runs cleanly under the .NET 10 SDK.