### PR TITLE
MessagingComparisons: retarget net10.0, pin MassTransit to v8 line (8.5.10)

### DIFF
--- a/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.Domain/MessagingComparisons.Domain.csproj
+++ b/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.Domain/MessagingComparisons.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.MassTransit.Tests/MessagingComparisons.MassTransit.Tests.csproj
+++ b/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.MassTransit.Tests/MessagingComparisons.MassTransit.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MassTransit.Abstractions" Version="8.3.0" />
+        <PackageReference Include="MassTransit.Abstractions" Version="8.5.10" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />

--- a/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.MassTransit/MessagingComparisons.MassTransit.csproj
+++ b/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.MassTransit/MessagingComparisons.MassTransit.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MassTransit" Version="8.3.0" />
-        <PackageReference Include="MassTransit.Newtonsoft" Version="8.3.0" />
+        <PackageReference Include="MassTransit" Version="8.5.10" />
+        <PackageReference Include="MassTransit.Newtonsoft" Version="8.5.10" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>

--- a/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.NServiceBus.Tests/MessagingComparisons.NServiceBus.Tests.csproj
+++ b/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.NServiceBus.Tests/MessagingComparisons.NServiceBus.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.NServiceBus/MessagingComparisons.NServiceBus.csproj
+++ b/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.NServiceBus/MessagingComparisons.NServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.Rebus.Tests/MessagingComparisons.Rebus.Tests.csproj
+++ b/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.Rebus.Tests/MessagingComparisons.Rebus.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.Rebus/MessagingComparisons.Rebus.csproj
+++ b/dotnet-client-libraries/MessagingComparisons/MessagingComparisons.Rebus/MessagingComparisons.Rebus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>


### PR DESCRIPTION
Retargets the MessagingComparisons solution (Domain, MassTransit, NServiceBus, Rebus + tests) to net10.0 and pins MassTransit to the free Apache-2.0 v8 line (8.5.10). Build and all tests green on net10.0.