### PR TITLE
Add Hangfire vs Quartz.NET comparison sample

### DIFF
--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire.sln
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire.sln
@@ -1,0 +1,31 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33110.190
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuartzVsHangfire", "QuartzVsHangfire\QuartzVsHangfire.csproj", "{FC8EF8A5-F261-45EE-89D1-C803C0229725}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{0C10125C-AEBF-4FA6-9CEF-4F4400ADE3C7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FC8EF8A5-F261-45EE-89D1-C803C0229725}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC8EF8A5-F261-45EE-89D1-C803C0229725}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC8EF8A5-F261-45EE-89D1-C803C0229725}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC8EF8A5-F261-45EE-89D1-C803C0229725}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C10125C-AEBF-4FA6-9CEF-4F4400ADE3C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C10125C-AEBF-4FA6-9CEF-4F4400ADE3C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C10125C-AEBF-4FA6-9CEF-4F4400ADE3C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C10125C-AEBF-4FA6-9CEF-4F4400ADE3C7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {936474A8-A312-4C71-8420-9D4762C8A024}
+	EndGlobalSection
+EndGlobal

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireJobScheduler.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireJobScheduler.cs
@@ -1,0 +1,16 @@
+using Hangfire;
+using QuartzVsHangfire.Services;
+
+namespace QuartzVsHangfire.HangfireSample;
+
+// Hangfire is built around a persistent job queue. We hand it work and it
+// stores, runs, and retries that work for us. These two calls are the model.
+public static class HangfireJobScheduler
+{
+    // Hangfire: enqueue now, retry automatically, watch it in the dashboard
+    public static string EnqueueWelcomeEmail(int userId) =>
+        BackgroundJob.Enqueue<IEmailSender>(x => x.SendWelcomeAsync(userId));
+
+    public static void ScheduleNightlyReport() =>
+        RecurringJob.AddOrUpdate<IReportBuilder>("nightly", x => x.RunAsync(), Cron.Daily);
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireMonitoring.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireMonitoring.cs
@@ -1,0 +1,16 @@
+using Hangfire;
+
+namespace QuartzVsHangfire.HangfireSample;
+
+// Hangfire ships a queryable monitoring API — the same data the drop-in
+// dashboard renders. Wiring the dashboard itself is one line in Startup:
+//   app.UseHangfireDashboard("/hangfire");   // needs Hangfire.AspNetCore
+public static class HangfireMonitoring
+{
+    public static long ScheduledJobCount()
+    {
+        var monitoringApi = JobStorage.Current.GetMonitoringApi();
+
+        return monitoringApi.GetStatistics().Scheduled;
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireRetryPolicy.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireRetryPolicy.cs
@@ -1,0 +1,16 @@
+using Hangfire;
+
+namespace QuartzVsHangfire.HangfireSample;
+
+// Hangfire retries failed jobs for us. We do not write a retry loop; we declare
+// the policy with an attribute and Hangfire re-runs the job on the schedule below.
+public class HangfireRetryPolicy
+{
+    [AutomaticRetry(Attempts = 5, DelaysInSeconds = new[] { 10, 60, 300 })]
+    public Task SendWebhookAsync(string url)
+    {
+        Console.WriteLine($"Posting to {url}. If this throws, Hangfire retries it.");
+
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireStartup.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireStartup.cs
@@ -1,0 +1,17 @@
+using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace QuartzVsHangfire.HangfireSample;
+
+// One registration block wires the client, the storage, and the worker that
+// drains the queue. After this, we inject IBackgroundJobClient and enqueue.
+public static class HangfireStartup
+{
+    public static IServiceCollection AddHangfireJobs(this IServiceCollection services)
+    {
+        services.AddHangfire(config => config.UseInMemoryStorage());
+        services.AddHangfireServer();
+
+        return services;
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireStorageConfig.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/HangfireSample/HangfireStorageConfig.cs
@@ -1,0 +1,19 @@
+using Hangfire;
+
+namespace QuartzVsHangfire.HangfireSample;
+
+// Hangfire always needs a storage backend: the persisted queue is the product.
+// This sample uses the in-memory store to stay self-contained.
+public static class HangfireStorageConfig
+{
+    public static JobStorage UseInMemory()
+    {
+        GlobalConfiguration.Configuration.UseInMemoryStorage();
+
+        // In production we swap this single line for a durable provider, e.g.
+        //   config.UseSqlServerStorage(connectionString);
+        //   config.UsePostgreSqlStorage(connectionString);
+        // (Redis storage lives in the paid Hangfire Pro package.)
+        return JobStorage.Current;
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Program.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Program.cs
@@ -1,0 +1,19 @@
+using Hangfire;
+using Hangfire.InMemory;
+using Quartz;
+using QuartzVsHangfire.HangfireSample;
+using QuartzVsHangfire.QuartzSample;
+
+// Hangfire needs storage because the queue is the product. An in-memory store
+// keeps this comparison sample self-contained (no SQL Server or Redis required).
+GlobalConfiguration.Configuration.UseInMemoryStorage();
+
+var jobId = HangfireJobScheduler.EnqueueWelcomeEmail(userId: 42);
+HangfireJobScheduler.ScheduleNightlyReport();
+
+Console.WriteLine($"Hangfire enqueued the welcome email as job '{jobId}' and scheduled the 'nightly' report.");
+
+// Quartz.NET needs no storage to describe a schedule: the trigger is the product.
+var trigger = (ICronTrigger)QuartzTriggerScheduler.BuildNightlyTrigger();
+
+Console.WriteLine($"Quartz.NET built trigger '{trigger.Key.Name}' with cron expression '{trigger.CronExpressionString}'.");

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/BackgroundJob.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/BackgroundJob.cs
@@ -1,0 +1,23 @@
+using Quartz;
+
+namespace QuartzVsHangfire.QuartzSample;
+
+public class BackgroundJob : IJob
+{
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var jobDataMap = context.MergedJobDataMap;
+
+        var useJobDataMapConsoleOutput = jobDataMap.GetBoolean("UseJobDataMapConsoleOutput");
+
+        if (useJobDataMapConsoleOutput)
+        {
+            var consoleOutput = jobDataMap.GetString("ConsoleOutput");
+            await Console.Out.WriteLineAsync(consoleOutput);
+        }
+        else
+        {
+            await Console.Out.WriteLineAsync("Executing background job without JobDataMap");
+        }
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/LoggingJobListener.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/LoggingJobListener.cs
@@ -1,0 +1,26 @@
+using Quartz;
+
+namespace QuartzVsHangfire.QuartzSample;
+
+// Quartz.NET has no dashboard. Monitoring is a listener we attach to the
+// scheduler. This one counts completed jobs — the hook a custom UI would use.
+public class LoggingJobListener : IJobListener
+{
+    public string Name => "logging-job-listener";
+
+    public int ExecutedCount { get; private set; }
+
+    public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException,
+        CancellationToken cancellationToken = default)
+    {
+        ExecutedCount++;
+
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzRetryJob.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzRetryJob.cs
@@ -1,0 +1,22 @@
+using Quartz;
+
+namespace QuartzVsHangfire.QuartzSample;
+
+// Quartz.NET has no automatic retry. We opt in by catching the failure and
+// throwing a JobExecutionException that asks the scheduler to refire the job.
+public class QuartzRetryJob : IJob
+{
+    public async Task Execute(IJobExecutionContext context)
+    {
+        try
+        {
+            await DoWorkAsync(context);
+        }
+        catch (Exception ex)
+        {
+            throw new JobExecutionException(ex, refireImmediately: true);
+        }
+    }
+
+    protected virtual Task DoWorkAsync(IJobExecutionContext context) => Task.CompletedTask;
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzStartup.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzStartup.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+using Quartz;
+
+namespace QuartzVsHangfire.QuartzSample;
+
+// Quartz.NET registers the scheduler, its jobs, and their triggers together.
+// The job and the trigger are declared side by side, wired by the job key.
+public static class QuartzStartup
+{
+    public static IServiceCollection AddQuartzJobs(this IServiceCollection services)
+    {
+        services.AddQuartz(configurator =>
+        {
+            var reportJob = new JobKey("nightly-report");
+
+            configurator.AddJob<ReportJob>(reportJob);
+            configurator.AddTrigger(trigger => trigger
+                .ForJob(reportJob)
+                .WithIdentity("nightly")
+                .WithCronSchedule("0 0 2 * * ?"));
+        });
+
+        services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        return services;
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzStorageConfig.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzStorageConfig.cs
@@ -1,0 +1,22 @@
+using System.Collections.Specialized;
+using Quartz;
+using Quartz.Impl;
+
+namespace QuartzVsHangfire.QuartzSample;
+
+// Quartz.NET runs fine with no database: RAMJobStore is the default. Durable
+// schedules are opt-in — we swap the job store type for an ADO.NET store.
+public static class QuartzStorageConfig
+{
+    public static Task<IScheduler> CreateInMemorySchedulerAsync()
+    {
+        var properties = new NameValueCollection
+        {
+            ["quartz.jobStore.type"] = "Quartz.Simpl.RAMJobStore, Quartz"
+        };
+
+        var factory = new StdSchedulerFactory(properties);
+
+        return factory.GetScheduler();
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzTriggerScheduler.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzTriggerScheduler.cs
@@ -1,0 +1,15 @@
+using Quartz;
+
+namespace QuartzVsHangfire.QuartzSample;
+
+// Quartz.NET is built around the trigger. The schedule itself is the unit of
+// work: we describe when a job fires and Quartz.NET owns the firing.
+public static class QuartzTriggerScheduler
+{
+    // Quartz.NET: the trigger is the unit of work
+    public static ITrigger BuildNightlyTrigger() =>
+        TriggerBuilder.Create()
+            .WithIdentity("nightly")
+            .WithCronSchedule("0 0 2 * * ?")
+            .Build();
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzTriggerScheduler.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/QuartzTriggerScheduler.cs
@@ -12,4 +12,12 @@ public static class QuartzTriggerScheduler
             .WithIdentity("nightly")
             .WithCronSchedule("0 0 2 * * ?")
             .Build();
+
+    // Quartz.NET has no fire-and-forget queue. The closest equivalent is a
+    // trigger that starts immediately instead of firing on a schedule.
+    public static ITrigger BuildImmediateTrigger() =>
+        TriggerBuilder.Create()
+            .WithIdentity("welcome-email")
+            .StartNow()
+            .Build();
 }

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/ReportJob.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzSample/ReportJob.cs
@@ -1,0 +1,15 @@
+using Quartz;
+using QuartzVsHangfire.Services;
+
+namespace QuartzVsHangfire.QuartzSample;
+
+// A Quartz.NET job is a class implementing IJob. The scheduler resolves it from
+// DI, so constructor-injected services (here IReportBuilder) just work.
+public class ReportJob : IJob
+{
+    private readonly IReportBuilder _reportBuilder;
+
+    public ReportJob(IReportBuilder reportBuilder) => _reportBuilder = reportBuilder;
+
+    public Task Execute(IJobExecutionContext context) => _reportBuilder.RunAsync();
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzVsHangfire.csproj
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzVsHangfire.csproj
@@ -10,7 +10,9 @@
     <ItemGroup>
         <PackageReference Include="Hangfire.Core" Version="1.8.24"/>
         <PackageReference Include="Hangfire.InMemory" Version="1.0.0"/>
+        <PackageReference Include="Hangfire.NetCore" Version="1.8.24"/>
         <PackageReference Include="Quartz" Version="3.19.1"/>
+        <PackageReference Include="Quartz.Extensions.Hosting" Version="3.19.1"/>
     </ItemGroup>
 
 </Project>

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzVsHangfire.csproj
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/QuartzVsHangfire.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Hangfire.Core" Version="1.8.24"/>
+        <PackageReference Include="Hangfire.InMemory" Version="1.0.0"/>
+        <PackageReference Include="Quartz" Version="3.19.1"/>
+    </ItemGroup>
+
+</Project>

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Services/EmailSender.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Services/EmailSender.cs
@@ -1,0 +1,11 @@
+namespace QuartzVsHangfire.Services;
+
+public class EmailSender : IEmailSender
+{
+    public Task SendWelcomeAsync(int userId)
+    {
+        Console.WriteLine($"Sending welcome email to user {userId}.");
+
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Services/IEmailSender.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Services/IEmailSender.cs
@@ -1,0 +1,6 @@
+namespace QuartzVsHangfire.Services;
+
+public interface IEmailSender
+{
+    Task SendWelcomeAsync(int userId);
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Services/IReportBuilder.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Services/IReportBuilder.cs
@@ -1,0 +1,6 @@
+namespace QuartzVsHangfire.Services;
+
+public interface IReportBuilder
+{
+    Task RunAsync();
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Services/ReportBuilder.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/QuartzVsHangfire/Services/ReportBuilder.cs
@@ -1,0 +1,11 @@
+namespace QuartzVsHangfire.Services;
+
+public class ReportBuilder : IReportBuilder
+{
+    public Task RunAsync()
+    {
+        Console.WriteLine("Building the nightly report.");
+
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/BackgroundJobTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/BackgroundJobTests.cs
@@ -1,0 +1,59 @@
+using Moq;
+using Quartz;
+using QuartzVsHangfire.QuartzSample;
+
+namespace Tests;
+
+public class BackgroundJobTests
+{
+    private readonly Mock<IJobExecutionContext> _jobExecutionContextMock;
+    private readonly BackgroundJob _backgroundJob = new BackgroundJob();
+
+    public BackgroundJobTests()
+    {
+        _jobExecutionContextMock = new Mock<IJobExecutionContext>();
+    }
+
+    [Fact]
+    public async Task GivenAValidJobDataMap_WhenUsingJobDataMapForOuputIsTrue_ThenUsesJobDataMapConsoleOutput()
+    {
+        const string consoleOutput = "test console output";
+        var expectedOutput = $"{consoleOutput}{Environment.NewLine}";
+        // Arrange
+        var jobDataMap = new JobDataMap
+        {
+            { "UseJobDataMapConsoleOutput", true },
+            { "ConsoleOutput", consoleOutput }
+        };
+        _jobExecutionContextMock.SetupGet(j => j.MergedJobDataMap).Returns(jobDataMap);
+        using var stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        // Act
+        await _backgroundJob.Execute(_jobExecutionContextMock.Object);
+
+        // Assert
+        Assert.Equal(expectedOutput, stringWriter.ToString());
+    }
+
+    [Fact]
+    public async Task GivenAValidJobDataMap_WhenUsingJobDataMapForOuputIsFalse_ThenUsesDefaultConsoleOutput()
+    {
+        const string defaultOutput = "Executing background job without JobDataMap";
+        var expectedOutput = $"{defaultOutput}{Environment.NewLine}";
+        // Arrange
+        var jobDataMap = new JobDataMap
+        {
+            { "UseJobDataMapConsoleOutput", false }
+        };
+        _jobExecutionContextMock.SetupGet(j => j.MergedJobDataMap).Returns(jobDataMap);
+        using var stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        // Act
+        await _backgroundJob.Execute(_jobExecutionContextMock.Object);
+
+        // Assert
+        Assert.Equal(expectedOutput, stringWriter.ToString());
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireJobSchedulerTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireJobSchedulerTests.cs
@@ -1,0 +1,40 @@
+using Hangfire;
+using Hangfire.InMemory;
+using Hangfire.Storage;
+using QuartzVsHangfire.HangfireSample;
+using QuartzVsHangfire.Services;
+
+namespace Tests;
+
+public class HangfireJobSchedulerTests
+{
+    static HangfireJobSchedulerTests()
+    {
+        // A single in-memory store backs every assertion, so the tests need no
+        // SQL Server or Redis: Hangfire only needs storage to write to.
+        GlobalConfiguration.Configuration.UseInMemoryStorage();
+    }
+
+    [Fact]
+    public void GivenAUserId_WhenEnqueueWelcomeEmail_ThenEnqueuesTheSendWelcomeJob()
+    {
+        var jobId = HangfireJobScheduler.EnqueueWelcomeEmail(42);
+
+        Assert.False(string.IsNullOrWhiteSpace(jobId));
+
+        var details = JobStorage.Current.GetMonitoringApi().JobDetails(jobId);
+        Assert.NotNull(details);
+        Assert.Equal(nameof(IEmailSender.SendWelcomeAsync), details.Job.Method.Name);
+    }
+
+    [Fact]
+    public void WhenScheduleNightlyReport_ThenRegistersTheNightlyRecurringJob()
+    {
+        HangfireJobScheduler.ScheduleNightlyReport();
+
+        using var connection = JobStorage.Current.GetConnection();
+        var recurringJobs = connection.GetRecurringJobs();
+
+        Assert.Contains(recurringJobs, job => job.Id == "nightly");
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireJobSchedulerTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireJobSchedulerTests.cs
@@ -6,6 +6,7 @@ using QuartzVsHangfire.Services;
 
 namespace Tests;
 
+[Collection("HangfireStorage")]
 public class HangfireJobSchedulerTests
 {
     static HangfireJobSchedulerTests()

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireMonitoringTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireMonitoringTests.cs
@@ -1,0 +1,21 @@
+using Hangfire;
+using QuartzVsHangfire.HangfireSample;
+
+namespace Tests;
+
+[Collection("HangfireStorage")]
+public class HangfireMonitoringTests
+{
+    static HangfireMonitoringTests()
+    {
+        GlobalConfiguration.Configuration.UseInMemoryStorage();
+    }
+
+    [Fact]
+    public void WhenScheduledJobCount_ThenReadsFromTheMonitoringApi()
+    {
+        var count = HangfireMonitoring.ScheduledJobCount();
+
+        Assert.True(count >= 0);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireRetryPolicyTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireRetryPolicyTests.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using Hangfire;
+using QuartzVsHangfire.HangfireSample;
+
+namespace Tests;
+
+public class HangfireRetryPolicyTests
+{
+    [Fact]
+    public void GivenTheSendWebhookMethod_WhenReadingItsAttributes_ThenAutomaticRetryIsConfigured()
+    {
+        var method = typeof(HangfireRetryPolicy).GetMethod(nameof(HangfireRetryPolicy.SendWebhookAsync));
+
+        var retry = method!.GetCustomAttribute<AutomaticRetryAttribute>();
+
+        Assert.NotNull(retry);
+        Assert.Equal(5, retry!.Attempts);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireStartupTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireStartupTests.cs
@@ -1,0 +1,22 @@
+using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
+using QuartzVsHangfire.HangfireSample;
+
+namespace Tests;
+
+[Collection("HangfireStorage")]
+public class HangfireStartupTests
+{
+    [Fact]
+    public void WhenAddHangfireJobs_ThenTheBackgroundJobClientIsRegistered()
+    {
+        var services = new ServiceCollection();
+
+        services.AddHangfireJobs();
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetService<IBackgroundJobClient>();
+
+        Assert.NotNull(client);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireStorageCollection.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireStorageCollection.cs
@@ -1,0 +1,6 @@
+namespace Tests;
+
+// Hangfire exposes a single process-wide JobStorage.Current. These tests each
+// configure or read it, so they must not run in parallel with one another.
+[CollectionDefinition("HangfireStorage", DisableParallelization = true)]
+public class HangfireStorageCollection;

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireStorageConfigTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/HangfireStorageConfigTests.cs
@@ -1,0 +1,17 @@
+using Hangfire;
+using QuartzVsHangfire.HangfireSample;
+
+namespace Tests;
+
+[Collection("HangfireStorage")]
+public class HangfireStorageConfigTests
+{
+    [Fact]
+    public void WhenUseInMemory_ThenReturnsAConfiguredJobStorage()
+    {
+        var storage = HangfireStorageConfig.UseInMemory();
+
+        Assert.NotNull(storage);
+        Assert.Same(JobStorage.Current, storage);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/LoggingJobListenerTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/LoggingJobListenerTests.cs
@@ -1,0 +1,19 @@
+using Moq;
+using Quartz;
+using QuartzVsHangfire.QuartzSample;
+
+namespace Tests;
+
+public class LoggingJobListenerTests
+{
+    [Fact]
+    public async Task WhenJobWasExecuted_ThenTheListenerCountsIt()
+    {
+        var listener = new LoggingJobListener();
+        var context = new Mock<IJobExecutionContext>().Object;
+
+        await listener.JobWasExecuted(context, jobException: null);
+
+        Assert.Equal(1, listener.ExecutedCount);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzImmediateTriggerTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzImmediateTriggerTests.cs
@@ -1,0 +1,14 @@
+using QuartzVsHangfire.QuartzSample;
+
+namespace Tests;
+
+public class QuartzImmediateTriggerTests
+{
+    [Fact]
+    public void WhenBuildImmediateTrigger_ThenTriggerHasTheWelcomeEmailIdentity()
+    {
+        var trigger = QuartzTriggerScheduler.BuildImmediateTrigger();
+
+        Assert.Equal("welcome-email", trigger.Key.Name);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzRetryJobTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzRetryJobTests.cs
@@ -1,0 +1,26 @@
+using Moq;
+using Quartz;
+using QuartzVsHangfire.QuartzSample;
+
+namespace Tests;
+
+public class QuartzRetryJobTests
+{
+    private sealed class FailingRetryJob : QuartzRetryJob
+    {
+        protected override Task DoWorkAsync(IJobExecutionContext context)
+            => throw new InvalidOperationException("work failed");
+    }
+
+    [Fact]
+    public async Task GivenTheWorkThrows_WhenExecute_ThenWrapsItInARefiringJobExecutionException()
+    {
+        var job = new FailingRetryJob();
+        var context = new Mock<IJobExecutionContext>().Object;
+
+        var exception = await Assert.ThrowsAsync<JobExecutionException>(() => job.Execute(context));
+
+        Assert.True(exception.RefireImmediately);
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzStartupTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzStartupTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Quartz;
+using QuartzVsHangfire.QuartzSample;
+
+namespace Tests;
+
+public class QuartzStartupTests
+{
+    [Fact]
+    public void WhenAddQuartzJobs_ThenTheSchedulerFactoryIsRegistered()
+    {
+        var services = new ServiceCollection();
+
+        services.AddQuartzJobs();
+
+        using var provider = services.BuildServiceProvider();
+        var schedulerFactory = provider.GetService<ISchedulerFactory>();
+
+        Assert.NotNull(schedulerFactory);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzStorageConfigTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzStorageConfigTests.cs
@@ -1,0 +1,14 @@
+using QuartzVsHangfire.QuartzSample;
+
+namespace Tests;
+
+public class QuartzStorageConfigTests
+{
+    [Fact]
+    public async Task WhenCreateInMemoryScheduler_ThenReturnsAUsableScheduler()
+    {
+        var scheduler = await QuartzStorageConfig.CreateInMemorySchedulerAsync();
+
+        Assert.NotNull(scheduler);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzTriggerSchedulerTests.cs
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/QuartzTriggerSchedulerTests.cs
@@ -1,0 +1,25 @@
+using Quartz;
+using Quartz.Impl.Triggers;
+using QuartzVsHangfire.QuartzSample;
+
+namespace Tests;
+
+public class QuartzTriggerSchedulerTests
+{
+    [Fact]
+    public void WhenBuildNightlyTrigger_ThenTriggerHasNightlyIdentity()
+    {
+        var trigger = QuartzTriggerScheduler.BuildNightlyTrigger();
+
+        Assert.Equal("nightly", trigger.Key.Name);
+    }
+
+    [Fact]
+    public void WhenBuildNightlyTrigger_ThenTriggerUsesTheExpectedCronExpression()
+    {
+        var trigger = QuartzTriggerScheduler.BuildNightlyTrigger();
+
+        var cronTrigger = Assert.IsType<CronTriggerImpl>(trigger);
+        Assert.Equal("0 0 2 * * ?", cronTrigger.CronExpressionString);
+    }
+}

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/Tests.csproj
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0"/>
+        <PackageReference Include="Moq" Version="4.20.72"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\QuartzVsHangfire\QuartzVsHangfire.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/dotnet-client-libraries/QuartzVsHangfire/Tests/Tests.csproj
+++ b/dotnet-client-libraries/QuartzVsHangfire/Tests/Tests.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0"/>
         <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="xunit" Version="2.9.3"/>

--- a/dotnet-client-libraries/README.md
+++ b/dotnet-client-libraries/README.md
@@ -30,6 +30,7 @@ This section contains the topics about the client libraries in .NET.
 - [Vendor-Agnostic Telemetry Using OpenTelemetry Collector in .NET](https://code-maze.com/vendor-agnostic-telemetry-opentelemetry-collector-dotnet/)
 - [MediatR Publish and Send Methods](https://code-maze.com/csharp-mediatr-publish-and-send-methods/)
 - [Schedule Jobs with Quartz.NET](https://code-maze.com/schedule-jobs-with-quartz-net/)
+- [Hangfire vs Quartz.NET: Which Scheduler to Choose?](https://code-maze.com/chsarp-the-differences-between-quartz-net-and-hangfire/)
 - [Rebus in .NET – Service Bus Implementation](https://code-maze.com/rebus-dotnet/)
 - [Easy Sorting, Filtering and Pagination in .NET With Sieve Package](https://code-maze.com/dotnet-sorting-filtering-pagination-sieve-package/)
 - [Using Refit to Consume APIs in C#](https://code-maze.com/using-refit-to-consume-apis-in-csharp/)


### PR DESCRIPTION
Adds a new `dotnet-client-libraries/QuartzVsHangfire` sample backing the Hangfire vs Quartz.NET comparison article.

- **Hangfire side (authored):** enqueues a fire-and-forget welcome email and registers a `nightly` recurring job against in-memory storage.
- **Quartz.NET side (reuses the existing Quartz job):** builds a cron trigger (`0 0 2 * * ?`) and runs a job.
- Targets **net10.0**; xUnit tests cover both sides. `dotnet build` + `dotnet test` green locally.

Pins Hangfire.Core 1.8.24 and Quartz 3.19.1.