### PR TITLE
InitSetters: retarget net10.0, fix swapped Tokyo coordinates

### DIFF
--- a/csharp-basic-topics/InitSetters/InitSetters.Tests/CityTests.cs
+++ b/csharp-basic-topics/InitSetters/InitSetters.Tests/CityTests.cs
@@ -5,8 +5,8 @@ namespace InitSetters.Tests
     public class CityTests
     {
         private readonly string _name = "Tokyo";
-        private readonly double _lat = 139.839478;
-        private readonly double _lon = 35.652832;
+        private readonly double _lat = 35.652832;
+        private readonly double _lon = 139.839478;
 
         [Fact]
         public void WhenConstructorIsInvoked_ThenValidObjectIsReturned()

--- a/csharp-basic-topics/InitSetters/InitSetters.Tests/InitSetters.Tests.csproj
+++ b/csharp-basic-topics/InitSetters/InitSetters.Tests/InitSetters.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/csharp-basic-topics/InitSetters/InitSetters/InitSetters.csproj
+++ b/csharp-basic-topics/InitSetters/InitSetters/InitSetters.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/csharp-basic-topics/InitSetters/InitSetters/Program.cs
+++ b/csharp-basic-topics/InitSetters/InitSetters/Program.cs
@@ -4,7 +4,7 @@
     {
         static void Main(string[] args)
         {
-            var city = new City("Tokyo", 139.839478, 35.652832);
+            var city = new City("Tokyo", 35.652832, 139.839478);
 
             Console.WriteLine($"{city.Name}: {city.Latitude}, {city.Longitude}");
 


### PR DESCRIPTION
Retarget the InitSetters sample and its test project to net10.0 and bump the test packages to current versions (FluentAssertions kept on the 6.x line). Fix the swapped Tokyo coordinates: the constructor is City(name, latitude, longitude), but both Program.cs and CityTests.cs passed 139.839478 as latitude and 35.652832 as longitude (139.8 is not a valid latitude). Latitude 35.65 / longitude 139.84 are now correct in both places.