### PR TITLE
HashSet in C#: modernize to .NET 10 and fix test defects

### DIFF
--- a/collections-csharp/HashSetInCSharp/HashSetInCSharp/HashSetInCSharp.csproj
+++ b/collections-csharp/HashSetInCSharp/HashSetInCSharp/HashSetInCSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/collections-csharp/HashSetInCSharp/HashSetInCSharp/HashSetsInCSharpMethods.cs
+++ b/collections-csharp/HashSetInCSharp/HashSetInCSharp/HashSetsInCSharpMethods.cs
@@ -50,7 +50,7 @@
             var rand = new Random();
             var numbers = new HashSet<int>();
 
-            for (int i = 0; i < size; i++) 
+            while (numbers.Count < size)
             {
                 numbers.Add(rand.Next());
             }

--- a/collections-csharp/HashSetInCSharp/HashSetInCSharpTests/HashSetInCSharpTests.csproj
+++ b/collections-csharp/HashSetInCSharp/HashSetInCSharpTests/HashSetInCSharpTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/collections-csharp/HashSetInCSharp/HashSetInCSharpTests/HashSetInCSharpUnitTests.cs
+++ b/collections-csharp/HashSetInCSharp/HashSetInCSharpTests/HashSetInCSharpUnitTests.cs
@@ -17,7 +17,7 @@ namespace HashSetInCSharpTests
         public void GivenAHashSet_WhenNotEmpty_VerifyCountAndContains()
         {
             Assert.IsInstanceOfType(_languages, typeof(HashSet<string>));
-            Assert.AreEqual(_languages.Count(), 9);
+            Assert.AreEqual(9, _languages.Count);
             Assert.IsTrue(_languages.Contains("C#"));
         }
 
@@ -29,7 +29,7 @@ namespace HashSetInCSharpTests
             _languages.Add("C#");
            
             Assert.IsInstanceOfType(_languages, typeof(HashSet<string>));
-            Assert.AreEqual(_languages.Count(), 9);
+            Assert.AreEqual(9, _languages.Count);
         }
 
         [TestMethod]
@@ -40,7 +40,7 @@ namespace HashSetInCSharpTests
             var updatedLanguages = hashSet.RemoveElement(_languages, elementToRemove);
 
             Assert.IsFalse(updatedLanguages.Contains(elementToRemove));
-            Assert.AreEqual(_languages.Count(), 8);
+            Assert.AreEqual(8, _languages.Count);
         }
 
         [TestMethod]
@@ -63,7 +63,7 @@ namespace HashSetInCSharpTests
             
             Assert.IsTrue(checkValue);
             Assert.IsFalse(oddNumbers.IsSubsetOf(numbers));
-            Assert.AreEqual(numbers.Union(oddNumbers).Count(), 100);
+            Assert.AreEqual(100, numbers.Union(oddNumbers).Count());
         }
 
         [TestMethod]
@@ -71,7 +71,7 @@ namespace HashSetInCSharpTests
         {
             _languages.Clear();
 
-            Assert.AreEqual(0, _languages.Count());
+            Assert.AreEqual(0, _languages.Count);
             Assert.IsNull(_languages.FirstOrDefault());
         }
 
@@ -83,7 +83,7 @@ namespace HashSetInCSharpTests
             var numbersList = hashSet.CreateList(numbers);
 
             CollectionAssert.AllItemsAreInstancesOfType(numbersList, typeof(int));
-            Assert.AreEqual(numbersList.Count(), numbers.Count());
+            Assert.AreEqual(numbers.Count, numbersList.Count);
         }
 
         [TestMethod]
@@ -103,7 +103,7 @@ namespace HashSetInCSharpTests
             var moreLanguages = new HashSet<string> { "Assembly", "Pascal", "HTML", "CSS", "PHP" };
 
             _languages.UnionWith(moreLanguages);
-            Assert.AreEqual(_languages.Count(), 14);
+            Assert.AreEqual(14, _languages.Count);
         }
 
         [TestMethod]
@@ -113,7 +113,7 @@ namespace HashSetInCSharpTests
 
             _languages.IntersectWith(moreLanguages);
 
-            Assert.AreEqual(_languages.Count(), 5);
+            Assert.AreEqual(5, _languages.Count);
             Assert.IsTrue(_languages.Contains("C"));
             Assert.IsTrue(_languages.Contains("C++"));
             Assert.IsTrue(_languages.Contains("C#"));
@@ -129,7 +129,7 @@ namespace HashSetInCSharpTests
 
             _languages.ExceptWith(moreLanguages);
 
-            Assert.AreEqual(_languages.Count(), 4);
+            Assert.AreEqual(4, _languages.Count);
             Assert.IsTrue(_languages.Contains("TypeScript"));
             Assert.IsTrue(_languages.Contains("Python"));
             Assert.IsTrue(_languages.Contains("JavaScript"));
@@ -143,8 +143,8 @@ namespace HashSetInCSharpTests
             var moreLanguages = new HashSet<string> { "Assembly", "Pascal", "HTML", "CSS", "PHP" };
 
             _languages.SymmetricExceptWith(moreLanguages);
-            
-            Assert.AreEqual(_languages.Count(), 14);
+
+            Assert.AreEqual(14, _languages.Count);
         }
 
         [TestMethod]


### PR DESCRIPTION
Modernizes the HashSetInCSharp sample to .NET 10 and fixes three real test defects: LINQ `Count()` where the `Count` property is correct, reversed `Assert.AreEqual` argument order, and a non-deterministic `RandomInts` that could flake on hash collisions. Package versions bumped to current stable (MSTest 4.3.3, Microsoft.NET.Test.Sdk 18.9.0, coverlet.collector 10.0.1). Build clean, 12/12 tests pass on net10.0.