### PR TITLE
String Split: fix cross-platform newline split; retarget net10.0

### DIFF
--- a/strings-csharp/SplitString/SplitString/Program.cs
+++ b/strings-csharp/SplitString/SplitString/Program.cs
@@ -99,7 +99,7 @@
 
         public static string[] SplitStringIntoNewLines(string multiLineText, string[] separators)
         {
-            string[] lines = multiLineText.Split(separators, StringSplitOptions.None);
+            string[] lines = multiLineText.ReplaceLineEndings().Split(separators, StringSplitOptions.None);
 
             foreach (string line in lines) 
             { 

--- a/strings-csharp/SplitString/SplitString/SplitString.csproj
+++ b/strings-csharp/SplitString/SplitString/SplitString.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/strings-csharp/SplitString/SplitStringTests/SplitStringTests.csproj
+++ b/strings-csharp/SplitString/SplitStringTests/SplitStringTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Retargets the SplitString sample to net10.0 and bumps its test packages to current stable (MSTest 4.3.3, Microsoft.NET.Test.Sdk 18.9.0, coverlet 10.0.1).

Fixes the new-lines example, which split a `\n`-only input on `Environment.NewLine` (`\r\n` on Windows) yet asserted five elements — so the test returned one element and failed on Windows. Normalising with `ReplaceLineEndings()` before the split makes it deterministic on any OS. All 7 tests pass on net10.0.