### PR TITLE
Encode URL components, not whole URLs, in UrlEncodingAndDecoding

### DIFF
--- a/aspnetcore-features/UrlEncodingAndDecoding/Tests/Tests.csproj
+++ b/aspnetcore-features/UrlEncodingAndDecoding/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore-features/UrlEncodingAndDecoding/Tests/UrlEncodingDecodingUnitTest.cs
+++ b/aspnetcore-features/UrlEncodingAndDecoding/Tests/UrlEncodingDecodingUnitTest.cs
@@ -6,74 +6,64 @@ namespace Tests
     [TestClass]
     public class UrlEncodingDecodingUnitTest
     {
-        private const string Url = @"http://example.com/resource?foo=bar with space#fragment";
-        private const string EncodedUrlLowerPlus = @"http%3a%2f%2fexample.com%2fresource%3ffoo%3dbar+with+space%23fragment";
-        private const string EncodedUrlUpperPercent = @"http%3A%2F%2Fexample.com%2Fresource%3Ffoo%3Dbar%20with%20space%23fragment";
-        private const string EncodedUrlUpperPlus = @"http%3A%2F%2Fexample.com%2Fresource%3Ffoo%3Dbar+with+space%23fragment";
+        private const string Value = "bar with space&more";
+        private const string EncodedWithPlus = "bar+with+space%26more";
+        private const string EncodedWithPercent = "bar%20with%20space%26more";
 
         [TestMethod]
-        public void GivenAUrl_WhenEncodingWithHttpUtility_ThenCharactersEncoded()
+        public void GivenAValue_WhenEncodingWithHttpUtility_ThenSpaceBecomesPlus()
         {
-            var encoded = HttpUtility.UrlEncode(Url);
+            var encoded = HttpUtility.UrlEncode(Value);
 
-            Assert.AreEqual(EncodedUrlLowerPlus, encoded);
-        }
-
-        [DataRow(EncodedUrlLowerPlus)]
-        [DataRow(EncodedUrlUpperPercent)]
-        [DataRow(EncodedUrlUpperPlus)]
-        [DataTestMethod]
-        public void GivenAUrl_WhenDecodingWithHttpUtility_ThenCharactersDecoded(string encodedUrl)
-        {
-            var decoded = HttpUtility.UrlDecode(encodedUrl);
-
-            Assert.AreEqual(Url, decoded);
+            Assert.AreEqual(EncodedWithPlus, encoded);
         }
 
         [TestMethod]
-        public void GivenAUrl_WhenEncodingWithWebUtility_ThenCharactersEncoded()
+        public void GivenAValue_WhenEncodingWithWebUtility_ThenSpaceBecomesPlus()
         {
-            var encoded = WebUtility.UrlEncode(Url);
+            var encoded = WebUtility.UrlEncode(Value);
 
-            Assert.AreEqual(EncodedUrlUpperPlus, encoded);
-        }
-
-        [DataRow(EncodedUrlLowerPlus)]
-        [DataRow(EncodedUrlUpperPercent)]
-        [DataRow(EncodedUrlUpperPlus)]
-        [DataTestMethod]
-        public void GivenAUrl_WhenDecodingWithWebUtility_ThenCharactersDecoded(string encodedUrl)
-        {
-            var decoded = WebUtility.UrlDecode(encodedUrl);
-
-            Assert.AreEqual(Url, decoded);
+            Assert.AreEqual(EncodedWithPlus, encoded);
         }
 
         [TestMethod]
-        public void GivenAUrl_WhenEncodingWithUri_ThenCharactersEncoded()
+        public void GivenAValue_WhenEncodingWithUri_ThenSpaceBecomesPercent20()
         {
-            var encoded = Uri.EscapeDataString(Url);
+            var encoded = Uri.EscapeDataString(Value);
 
-            Assert.AreEqual(EncodedUrlUpperPercent, encoded);
+            Assert.AreEqual(EncodedWithPercent, encoded);
         }
 
-        [DataRow(EncodedUrlUpperPercent)]
-        [DataTestMethod]
-        public void GivenAUrl_WhenDecodingWithUri_ThenCharactersDecoded(string encodedUrl)
+        [TestMethod]
+        public void GivenAnEncodedValue_WhenDecodingWithHttpUtility_ThenValueRestored()
         {
-            var decoded = Uri.UnescapeDataString(encodedUrl);
+            var decoded = HttpUtility.UrlDecode(EncodedWithPlus);
 
-            Assert.AreEqual(Url, decoded);
+            Assert.AreEqual(Value, decoded);
         }
 
-        [DataRow(EncodedUrlLowerPlus)]
-        [DataRow(EncodedUrlUpperPlus)]
-        [DataTestMethod]
-        public void GivenAUrl_WhenDecodingWithUri_ThenCharactersNotDecoded(string encodedUrl)
+        [TestMethod]
+        public void GivenAnEncodedValue_WhenDecodingWithWebUtility_ThenValueRestored()
         {
-            var decoded = Uri.UnescapeDataString(encodedUrl);
+            var decoded = WebUtility.UrlDecode(EncodedWithPlus);
 
-            Assert.AreNotEqual(Url, decoded); //Uri.UnescapeDataString does not decode + character to space
+            Assert.AreEqual(Value, decoded);
+        }
+
+        [TestMethod]
+        public void GivenAnEncodedValue_WhenDecodingWithUri_ThenValueRestored()
+        {
+            var decoded = Uri.UnescapeDataString(EncodedWithPercent);
+
+            Assert.AreEqual(Value, decoded);
+        }
+
+        [TestMethod]
+        public void GivenAPlusEncodedValue_WhenDecodingWithUri_ThenPlusIsNotConvertedToSpace()
+        {
+            var decoded = Uri.UnescapeDataString(EncodedWithPlus);
+
+            Assert.AreNotEqual(Value, decoded); // Uri.UnescapeDataString leaves '+' as a literal plus
         }
     }
 }

--- a/aspnetcore-features/UrlEncodingAndDecoding/UrlEncodingAndDecoding/Program.cs
+++ b/aspnetcore-features/UrlEncodingAndDecoding/UrlEncodingAndDecoding/Program.cs
@@ -1,21 +1,16 @@
-﻿using System.Net;
+using System.Net;
 using System.Web;
 
-var url = @"http://example.com/resource?foo=bar with space#fragment";
+var value = "bar with space&more";
 
-var httpUtilityEncoded = HttpUtility.UrlEncode(url);
-var httpUtilityDecoded = HttpUtility.UrlDecode(httpUtilityEncoded);
+var httpUtilityEncoded = HttpUtility.UrlEncode(value);
+var webUtilityEncoded = WebUtility.UrlEncode(value);
+var uriEncoded = Uri.EscapeDataString(value);
 
-var webUtilityEncoded = WebUtility.UrlEncode(url);
-var webUtilityDecoded = WebUtility.UrlDecode(webUtilityEncoded);
+Console.WriteLine($"http://example.com/resource?foo={httpUtilityEncoded}");
+Console.WriteLine($"http://example.com/resource?foo={webUtilityEncoded}");
+Console.WriteLine($"http://example.com/resource?foo={uriEncoded}");
 
-var uriEncoded = Uri.EscapeDataString(url);
-var uriDecoded = Uri.UnescapeDataString(uriEncoded);
-
-Console.WriteLine(httpUtilityEncoded);
-Console.WriteLine(webUtilityEncoded);
-Console.WriteLine(uriEncoded);
-
-Console.WriteLine(httpUtilityDecoded);
-Console.WriteLine(webUtilityDecoded);
-Console.WriteLine(uriDecoded);
+Console.WriteLine(HttpUtility.UrlDecode(httpUtilityEncoded));
+Console.WriteLine(WebUtility.UrlDecode(webUtilityEncoded));
+Console.WriteLine(Uri.UnescapeDataString(uriEncoded));

--- a/aspnetcore-features/UrlEncodingAndDecoding/UrlEncodingAndDecoding/UrlEncodingAndDecoding.csproj
+++ b/aspnetcore-features/UrlEncodingAndDecoding/UrlEncodingAndDecoding/UrlEncodingAndDecoding.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
The three examples (Program.cs and tests) encoded the entire URL `http://example.com/resource?foo=bar with space#fragment`, which percent-escapes the `://`, `?` and `#` that give a URL its structure and produces an unusable string. This reworks all three to encode only the query-string value and interpolate it into the URL, keeping the visible comparison between the classes (space as `+` vs `%20`). Also retargets both projects to net10.0 and updates the MSTest/test SDK packages.