### PR TITLE
Add DateOnly.ToDateTime reverse conversion and target .NET 10

### DIFF
--- a/dotnet-datetime/DateOnlyAndTimeOnlyInCSharp/DateOnlyAndTimeOnlyInCSharpExample/DateOnlyAndTimeOnlyInCSharpExample.csproj
+++ b/dotnet-datetime/DateOnlyAndTimeOnlyInCSharp/DateOnlyAndTimeOnlyInCSharpExample/DateOnlyAndTimeOnlyInCSharpExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/dotnet-datetime/DateOnlyAndTimeOnlyInCSharp/DateOnlyAndTimeOnlyInCSharpExample/Program.cs
+++ b/dotnet-datetime/DateOnlyAndTimeOnlyInCSharp/DateOnlyAndTimeOnlyInCSharpExample/Program.cs
@@ -60,6 +60,12 @@ public class Program
 
         Console.WriteLine(dateOnly);
         Console.WriteLine(timeOnly);
+
+        var backToDateTime = dateOnly.ToDateTime(timeOnly);
+        var atMidnight = dateOnly.ToDateTime(TimeOnly.MinValue);
+
+        Console.WriteLine(backToDateTime);
+        Console.WriteLine(atMidnight);
     }
 
     public static void DemonstrateBasicOperators()

--- a/dotnet-datetime/DateOnlyAndTimeOnlyInCSharp/Tests/DateOnlyTests.cs
+++ b/dotnet-datetime/DateOnlyAndTimeOnlyInCSharp/Tests/DateOnlyTests.cs
@@ -86,6 +86,23 @@ namespace Tests
         }
 
         [Fact]
+        public void CanConvertToDateTime()
+        {
+            // Arrange.
+            var dateOnly = new DateOnly(2022, 1, 1);
+            var timeOnly = new TimeOnly(11, 30);
+
+            // Act.
+            var dateTime = dateOnly.ToDateTime(timeOnly);
+            var atMidnight = dateOnly.ToDateTime(TimeOnly.MinValue);
+
+            // Assert.
+            Assert.Equal(new DateTime(2022, 1, 1, 11, 30, 0), dateTime);
+            Assert.Equal(new DateTime(2022, 1, 1, 0, 0, 0), atMidnight);
+            Assert.Equal(DateTimeKind.Unspecified, dateTime.Kind);
+        }
+
+        [Fact]
         public void CanUseLessThanOperator()
         {
             // Arrange.

--- a/dotnet-datetime/DateOnlyAndTimeOnlyInCSharp/Tests/Tests.csproj
+++ b/dotnet-datetime/DateOnlyAndTimeOnlyInCSharp/Tests/Tests.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Adds the reverse `DateOnly.ToDateTime(...)` conversion (both the with-time and midnight/`TimeOnly.MinValue` forms) to the DateOnly/TimeOnly sample, with a covering test, and retargets the sample and its tests to .NET 10. Accompanies the update to https://code-maze.com/csharp-dateonly-timeonly/