### PR TITLE
RateLimitingDotNET8: target net10.0, fix rejection status and auth partitioner

### DIFF
--- a/aspnetcore-webapi/RateLimitingDotNET8/RateLimitingDotNET8.Tests/RateLimitingDotNET8.Tests.csproj
+++ b/aspnetcore-webapi/RateLimitingDotNET8/RateLimitingDotNET8.Tests/RateLimitingDotNET8.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/aspnetcore-webapi/RateLimitingDotNET8/RateLimitingDotNET8/RateLimiters.cs
+++ b/aspnetcore-webapi/RateLimitingDotNET8/RateLimitingDotNET8/RateLimiters.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.RateLimiting;
+﻿using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 using System.Threading.RateLimiting;
 
@@ -11,14 +10,17 @@ public static class RateLimiters
     {
         var fixedOptions = GetOptionValues<FixedOptions>(builder);
 
-        builder.Services.AddRateLimiter(options => options
-            .AddFixedWindowLimiter(policyName: Policies.Fixed, limiterOptions =>
+        builder.Services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+            options.AddFixedWindowLimiter(policyName: Policies.Fixed, limiterOptions =>
             {
                 limiterOptions.PermitLimit = fixedOptions!.PermitLimit;
                 limiterOptions.Window = TimeSpan.FromMinutes(fixedOptions.Window);
                 limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
                 limiterOptions.QueueLimit = fixedOptions.QueueLimit;
-            }));
+            });
+        });
     }
 
     public static void SlidingRateLimiter(WebApplicationBuilder builder)
@@ -79,10 +81,10 @@ public static class RateLimiters
             limiterOptions.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
             limiterOptions.AddPolicy(policyName: Policies.Authorization, partitioner: httpContext =>
             {
-                var accessToken = httpContext.GetTokenAsync("access_token").Result;
+                var username = httpContext.User.Identity?.Name;
 
-                return !string.IsNullOrEmpty(accessToken)
-                    ? RateLimitPartition.GetFixedWindowLimiter(accessToken, options =>
+                return !string.IsNullOrEmpty(username)
+                    ? RateLimitPartition.GetFixedWindowLimiter(username, options =>
                         new FixedWindowRateLimiterOptions
                         {
                             QueueLimit = authorizedLimiterOptions!.QueueLimit,

--- a/aspnetcore-webapi/RateLimitingDotNET8/RateLimitingDotNET8/RateLimitingDotNET8.csproj
+++ b/aspnetcore-webapi/RateLimitingDotNET8/RateLimitingDotNET8/RateLimitingDotNET8.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Modernizes the `aspnetcore-webapi/RateLimitingDotNET8` sample and fixes two defects.

- Retarget the app and test projects to `net10.0` and refresh NuGet package versions.
- Set `RejectionStatusCode` to 429 on the fixed window registration so the documented fixed/sliding/token/concurrency limiters return 429 on their own, instead of relying on the authorization limiter's global setting (they otherwise fall back to the framework default 503).
- Replace the blocking `GetTokenAsync("access_token").Result` call in the authorization partitioner with a synchronous read of `httpContext.User.Identity?.Name`, avoiding sync-over-async on a per-request delegate and keying partitions on a stable user identity.

Build and all 14 tests pass on net10.0.