### PR TITLE
Modernize GlobalDefaultJsonSerializationoptions to .NET 10 and fix Newtonsoft global config

### DIFF
--- a/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptions/Controllers/ProductController.cs
+++ b/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptions/Controllers/ProductController.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 
 namespace GlobalDefaultJsonSerializationoptions.Controllers;
 
@@ -16,6 +15,6 @@ public class ProductController : ControllerBase
     [HttpPost("save")]
     public ActionResult SaveProduct(Product product)
     {
-        return Ok(JsonConvert.SerializeObject(product));
+        return Ok(product);
     }
 }

--- a/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptions.csproj
+++ b/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptions.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
 </Project>

--- a/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptions/Program.cs
+++ b/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptions/Program.cs
@@ -25,7 +25,7 @@ builder.Services.Configure<JsonOptions>(options =>
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
-    options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+    options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseUpper;
     options.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
     options.SerializerOptions.WriteIndented = false;
     options.SerializerOptions.Encoder = JavaScriptEncoder.Default;
@@ -34,15 +34,15 @@ builder.Services.ConfigureHttpJsonOptions(options =>
     options.SerializerOptions.NumberHandling = JsonNumberHandling.AllowReadingFromString;
 });
 
-JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+builder.Services.AddControllers().AddNewtonsoftJson(options =>
 {
-    ContractResolver = new CamelCasePropertyNamesContractResolver(),
-    Formatting = Formatting.Indented,
-    NullValueHandling = NullValueHandling.Ignore,
-    DateFormatString = "dd-MM-yyyy",
-    DefaultValueHandling = DefaultValueHandling.Ignore,
-    MaxDepth = 3
-};
+    options.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+    options.SerializerSettings.Formatting = Formatting.Indented;
+    options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+    options.SerializerSettings.DateFormatString = "dd-MM-yyyy";
+    options.SerializerSettings.DefaultValueHandling = DefaultValueHandling.Ignore;
+    options.SerializerSettings.MaxDepth = 3;
+});
 
 var app = builder.Build();
 

--- a/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptionsUnitTests/GlobalDefaultJsonSerializationoptionsUnitTests.csproj
+++ b/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptionsUnitTests/GlobalDefaultJsonSerializationoptionsUnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptionsUnitTests/ProductControllerUnitTests.cs
+++ b/json-csharp/GlobalDefaultJsonSerializationoptions/GlobalDefaultJsonSerializationoptionsUnitTests/ProductControllerUnitTests.cs
@@ -2,7 +2,6 @@ using GlobalDefaultJsonSerializationoptions;
 using GlobalDefaultJsonSerializationoptions.Controllers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 
 namespace GlobalDefaultJsonSerializationoptionsUnitTests;
 
@@ -42,8 +41,6 @@ public class ProductControllerUnitTests
         // Assert
         Assert.IsNotNull(result);
         Assert.AreEqual(200, result.StatusCode);
-
-        var expectedJson = JsonConvert.SerializeObject(product);
-        Assert.AreEqual(expectedJson, result?.Value?.ToString());
+        Assert.AreEqual(product, result.Value);
     }
 }


### PR DESCRIPTION
Modernizes the `json-csharp/GlobalDefaultJsonSerializationoptions` sample to .NET 10 and fixes the Newtonsoft global-configuration example.

- Retarget the app and unit-test projects to `net10.0`; refresh test packages.
- Configure Newtonsoft globally through `AddControllers().AddNewtonsoftJson(...)` (package `Microsoft.AspNetCore.Mvc.NewtonsoftJson`) rather than `JsonConvert.DefaultSettings`, which only affects direct `JsonConvert` calls and not the MVC output formatters.
- `SaveProduct` now returns `Ok(product)`, so the response goes through the formatter as JSON instead of a hand-serialized string that MVC writes as `text/plain`.
- The minimal-API `ConfigureHttpJsonOptions` uses `SnakeCaseUpper` to make clear that controller and minimal-API JSON options are independent types.

Build and tests pass on net10.0.
