### PR TITLE
Retarget DateTimeNowVsDateTimeUtcNow to net10.0

### DIFF
--- a/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNow.Tests/DateTimeNow.Tests.csproj
+++ b/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNow.Tests/DateTimeNow.Tests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNowVsDateTimeUtcNow/DateTimeNowVsDateTimeUtcNow.csproj
+++ b/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNowVsDateTimeUtcNow/DateTimeNowVsDateTimeUtcNow.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Retargets both projects in `dotnet-datetime/DateTimeNowVsDateTimeUtcNow` to net10.0 and bumps the test dependencies (Microsoft.NET.Test.Sdk, MSTest, coverlet) to current versions. Build and tests pass on net10.0.