### PR TITLE
Update DifferenceBetweenFieldsAndProperty sample to .NET 10

### DIFF
--- a/csharp-intermediate-topics/DifferenceBetweenFieldsAndProperty/DifferenceBetweenFieldsAndProperty/DifferenceBetweenFieldsAndProperty.csproj
+++ b/csharp-intermediate-topics/DifferenceBetweenFieldsAndProperty/DifferenceBetweenFieldsAndProperty/DifferenceBetweenFieldsAndProperty.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/csharp-intermediate-topics/DifferenceBetweenFieldsAndProperty/DifferenceBetweenFieldsAndProperty/RectangleWithFieldKeyword.cs
+++ b/csharp-intermediate-topics/DifferenceBetweenFieldsAndProperty/DifferenceBetweenFieldsAndProperty/RectangleWithFieldKeyword.cs
@@ -1,0 +1,14 @@
+namespace DifferenceBetweenFieldsAndProperty;
+
+// The same validation as Rectangle.Width, written with the C# 14 `field` keyword
+// instead of a hand-declared private backing field.
+public class RectangleWithFieldKeyword
+{
+    public double Width
+    {
+        get;
+        set => field = value >= 0
+            ? value
+            : throw new ArgumentException("A Rectangle can't have negative width", nameof(value));
+    }
+}

--- a/csharp-intermediate-topics/DifferenceBetweenFieldsAndProperty/Tests/Tests.cs
+++ b/csharp-intermediate-topics/DifferenceBetweenFieldsAndProperty/Tests/Tests.cs
@@ -20,4 +20,20 @@ public class Tests
 
         Assert.Equal(105, scaledRectangle.Height);
     }
+
+    [Fact]
+    public void GivenRectangleWithFieldKeyword_WhenAssigningNegativeWidth_ThenThrowsException()
+    {
+        var rectangle = new RectangleWithFieldKeyword();
+
+        Assert.Throws<ArgumentException>(() => rectangle.Width = -2);
+    }
+
+    [Fact]
+    public void GivenRectangleWithFieldKeyword_WhenAssigningValidWidth_ThenStoresValue()
+    {
+        var rectangle = new RectangleWithFieldKeyword { Width = 14 };
+
+        Assert.Equal(14, rectangle.Width);
+    }
 }

--- a/csharp-intermediate-topics/DifferenceBetweenFieldsAndProperty/Tests/Tests.csproj
+++ b/csharp-intermediate-topics/DifferenceBetweenFieldsAndProperty/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Retargets both projects in `csharp-intermediate-topics/DifferenceBetweenFieldsAndProperty` from net8.0 to net10.0 and adds `RectangleWithFieldKeyword`, which expresses the same width validation with the C# 14 `field` keyword next to the existing hand-written backing-field version, so both forms are in the sample.

Build and tests on net10.0: build succeeded with 0 warnings, 4/4 tests passing.