### PR TITLE
Update IEnumerable vs ICollection vs IList vs List sample to .NET 10

### DIFF
--- a/collections-csharp/IEnumerableVsICollectionVsIListVsList/IEnumerableVsICollectionVsIListVsList/DeferredExecutionDemo.cs
+++ b/collections-csharp/IEnumerableVsICollectionVsIListVsList/IEnumerableVsICollectionVsIListVsList/DeferredExecutionDemo.cs
@@ -1,0 +1,17 @@
+namespace IEnumerableVsICollectionVsIListVsList
+{
+    public class DeferredExecutionDemo
+    {
+        public void ShowDeferredVsMaterialised(IEnumerable<int> numbers)
+        {
+            IEnumerable<int> query = numbers.Where(n => n > 10);
+
+            Console.WriteLine(query.Count());   // runs the filter
+            Console.WriteLine(query.Count());   // runs the filter again
+
+            ICollection<int> materialised = query.ToList();
+
+            Console.WriteLine(materialised.Count);   // reads a stored value
+        }
+    }
+}

--- a/collections-csharp/IEnumerableVsICollectionVsIListVsList/IEnumerableVsICollectionVsIListVsList/IEnumerableVsICollectionVsIListVsList.csproj
+++ b/collections-csharp/IEnumerableVsICollectionVsIListVsList/IEnumerableVsICollectionVsIListVsList/IEnumerableVsICollectionVsIListVsList.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/collections-csharp/IEnumerableVsICollectionVsIListVsList/IEnumerableVsICollectionVsIListVsList/Program.cs
+++ b/collections-csharp/IEnumerableVsICollectionVsIListVsList/IEnumerableVsICollectionVsIListVsList/Program.cs
@@ -36,6 +36,11 @@ namespace IEnumerableVsICollectionVsIListVsList
             output = lst.CountSpecialCharacters(specialCharacter);
             Console.WriteLine($"List:{output}");
 
+            //Deferred execution vs a materialised collection
+            var deferred = new DeferredExecutionDemo();
+            Console.WriteLine($"Deferred vs materialised:");
+            deferred.ShowDeferredVsMaterialised(new List<int> { 5, 11, 12, 42 });
+
             Console.ReadLine();
         }       
     }    

--- a/collections-csharp/IEnumerableVsICollectionVsIListVsList/Tests/Tests.csproj
+++ b/collections-csharp/IEnumerableVsICollectionVsIListVsList/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Retargets both projects in `collections-csharp/IEnumerableVsICollectionVsIListVsList` from `net7.0` to `net10.0` and adds a deferred-execution demonstration to the sample.

- `DeferredExecutionDemo.ShowDeferredVsMaterialised()` shows that a LINQ query re-runs the filter on every enumeration, while a materialised `ICollection<T>` reads a stored `Count`.
- Wired into `Program.Main()` alongside the existing interface demos.

Verified locally on .NET 10.0.10: build clean, 7/7 NUnit tests passing.