### PR TITLE
DateTime.Now vs DateTime.UtcNow: retarget net10.0, bump test packages, add Unspecified conversion tests

### DIFF
--- a/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNow.Tests/DateTimeNow.Tests.csproj
+++ b/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNow.Tests/DateTimeNow.Tests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNow.Tests/DateTimeTests.cs
+++ b/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNow.Tests/DateTimeTests.cs
@@ -56,5 +56,27 @@ namespace DateTimeNow.Tests
 
             Assert.IsTrue(now.Kind == DateTimeKind.Local && utc.Kind == DateTimeKind.Utc);
         }
+
+        [TestMethod]
+        public void UnspecifiedDate_WhenConvertedToLocalTime_IsTreatedAsUtc()
+        {
+            var value = new DateTime(2022, 1, 9, 14, 34, 42);
+
+            var unspecified = DateTime.SpecifyKind(value, DateTimeKind.Unspecified);
+            var asUtc = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+
+            Assert.AreEqual(asUtc.ToLocalTime(), unspecified.ToLocalTime());
+        }
+
+        [TestMethod]
+        public void UnspecifiedDate_WhenConvertedToUniversalTime_IsTreatedAsLocal()
+        {
+            var value = new DateTime(2022, 1, 9, 14, 34, 42);
+
+            var unspecified = DateTime.SpecifyKind(value, DateTimeKind.Unspecified);
+            var asLocal = DateTime.SpecifyKind(value, DateTimeKind.Local);
+
+            Assert.AreEqual(asLocal.ToUniversalTime(), unspecified.ToUniversalTime());
+        }
     }
 }

--- a/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNowVsDateTimeUtcNow/DateTimeNowVsDateTimeUtcNow.csproj
+++ b/dotnet-datetime/DateTimeNowVsDateTimeUtcNow/DateTimeNowVsDateTimeUtcNow/DateTimeNowVsDateTimeUtcNow.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Supports the republish of [Difference Between DateTime.Now and DateTime.UtcNow in C#](https://code-maze.com/csharp-datetime-now-vs-datetime-utcnow/).

**What changed in `dotnet-datetime/DateTimeNowVsDateTimeUtcNow`:**

1. **Retarget both projects `net6.0` -> `net10.0`.** Console project and test project.
2. **Bump the test packages.** `Microsoft.NET.Test.Sdk` 16.11.0 -> 18.9.0, `MSTest.TestAdapter` / `MSTest.TestFramework` 2.2.7 -> 4.3.3, `coverlet.collector` 3.1.0 -> 10.0.1. Versions re-read from the NuGet flat-container API on 2026-08-30; a net6.0-era Test SDK will not run a net10.0 test project, so the bump is required by (1) rather than cosmetic.
3. **Two new tests in the existing `DateTimeTests` class** pinning the `DateTimeKind.Unspecified` asymmetry that the article's conversion section documents: `ToLocalTime()` treats an unflagged value as if it were UTC, while `ToUniversalTime()` treats the same value as if it were local. Both are written offset-agnostic (equality against `SpecifyKind(Utc)` / `SpecifyKind(Local)`) so they hold in a UTC CI container as well as on a machine with a non-zero offset.

No change to `Program.cs`: it is already top-level statements with implicit usings, and every snippet printed in the article matches it.

**Verified locally on SDK 10.0.302:** `dotnet build -c Release` succeeds, `dotnet test -c Release` passes 7/7.

Note: the MSTest 4.x analyzers report two `MSTEST0017` warnings (swapped expected/actual arguments) on two pre-existing assertions in `DateTimeTests.cs`. They are warnings only, they predate this PR, and they are left untouched to keep the diff to what the article needs.