### PR TITLE
Serialize a list to JSON: retarget net10.0, add stream serialization

### DIFF
--- a/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/Club.cs
+++ b/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/Club.cs
@@ -5,6 +5,6 @@
         public string Name { get; set; } = string.Empty;
         public int YearFounded { get; set; }
         public string Country { get; set; } = string.Empty;
-        public string NumberOfPlayers { get; set; } = string.Empty;
+        public int NumberOfPlayers { get; set; }
     }
 }

--- a/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/GenerateBenchmarkData.cs
+++ b/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/GenerateBenchmarkData.cs
@@ -12,7 +12,7 @@
                     Name = $"Club-{i}",
                     YearFounded = 1000 + i,
                     Country = "England",
-                    NumberOfPlayers = "30",
+                    NumberOfPlayers = 30,
                 };
                 englishClubs.Add(club);
             }

--- a/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp.csproj
+++ b/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
 </Project>

--- a/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/Program.cs
+++ b/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/Program.cs
@@ -1,12 +1,4 @@
 ﻿using BenchmarkDotNet.Running;
+using HowToSerializeAListToJsonInCSharp;
 
-namespace HowToSerializeAListToJsonInCSharp
-{
-    internal class Program
-    {
-        static void Main(string[] args)
-        {
-            BenchmarkRunner.Run<SerializeMethodsBenchmark>();
-        }
-    }
-}
+BenchmarkRunner.Run<SerializeMethodsBenchmark>();

--- a/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/SerializeListToJsonWithNewtonsoftJson.cs
+++ b/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/SerializeListToJsonWithNewtonsoftJson.cs
@@ -4,9 +4,8 @@ using System.Text;
 
 namespace HowToSerializeAListToJsonInCSharp
 {
-    public class SerializeListToJsonWithNewtonsoftJson
+    public class SerializeListToJsonWithNewtonsoftJson(List<Club> clubList)
     {
-        private readonly List<Club> _clubList;
         private readonly JsonSerializerSettings _settings
             = new()
             {
@@ -14,14 +13,9 @@ namespace HowToSerializeAListToJsonInCSharp
                 ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() },
             };
 
-        public SerializeListToJsonWithNewtonsoftJson(List<Club> clubList)
-        {
-            _clubList = clubList;
-        }
-
         public string SerializeObjectMethod()
         {
-            return JsonConvert.SerializeObject(_clubList, _settings);
+            return JsonConvert.SerializeObject(clubList, _settings);
         }
 
         public string JsonSerializerClass()
@@ -30,7 +24,7 @@ namespace HowToSerializeAListToJsonInCSharp
             var stringBuilder = new StringBuilder();
             using (var writer = new JsonTextWriter(new StringWriter(stringBuilder)))
             {
-                serializer.Serialize(writer, _clubList);
+                serializer.Serialize(writer, clubList);
             }
 
             return stringBuilder.ToString();

--- a/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/SerializeListToJsonWithSystemTextJson.cs
+++ b/json-csharp/HowToSerializeAListToJsonInCSharp/HowToSerializeAListToJsonInCSharp/SerializeListToJsonWithSystemTextJson.cs
@@ -2,31 +2,30 @@
 
 namespace HowToSerializeAListToJsonInCSharp
 {
-    public class SerializeListToJsonWithSystemTextJson
+    public class SerializeListToJsonWithSystemTextJson(List<Club> clubList)
     {
-        private readonly List<Club> _clubList;
-        private readonly JsonSerializerOptions _options 
-            = new() 
+        private readonly JsonSerializerOptions _options
+            = new()
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 WriteIndented = true,
             };
 
-        public SerializeListToJsonWithSystemTextJson(List<Club> clubList)
-        {
-            _clubList = clubList;
-        }
-
         public string SerializeMethod()
         {
-            return JsonSerializer.Serialize(_clubList, _options);
+            return JsonSerializer.Serialize(clubList, _options);
         }
 
         public string SerializeToUtf8BytesMethod()
         {
-            var result = JsonSerializer.SerializeToUtf8Bytes(_clubList, _options);
-            
+            var result = JsonSerializer.SerializeToUtf8Bytes(clubList, _options);
+
             return System.Text.Encoding.UTF8.GetString(result);
+        }
+
+        public async Task SerializeToStreamAsync(Stream stream)
+        {
+            await JsonSerializer.SerializeAsync(stream, clubList, _options);
         }
     }
 }

--- a/json-csharp/HowToSerializeAListToJsonInCSharp/Tests/NewtonsoftJsonMethodsTests.cs
+++ b/json-csharp/HowToSerializeAListToJsonInCSharp/Tests/NewtonsoftJsonMethodsTests.cs
@@ -11,21 +11,21 @@ namespace Tests
                     Name = "Arsenal",
                     YearFounded = 1886,
                     Country = "England",
-                    NumberOfPlayers = "26",
+                    NumberOfPlayers = 26,
                 },
                 new Club
                 {
                     Name = "Manchester City",
                     YearFounded = 1880,
                     Country = "England",
-                    NumberOfPlayers = "25",
+                    NumberOfPlayers = 25,
                 },
                 new Club
                 {
                     Name = "Sunderland",
                     YearFounded = 1879,
                     Country = "England",
-                    NumberOfPlayers = "30",
+                    NumberOfPlayers = 30,
                 }
             };
 
@@ -39,19 +39,19 @@ namespace Tests
                     "name": "Arsenal",
                     "yearFounded": 1886,
                     "country": "England",
-                    "numberOfPlayers": "26"
+                    "numberOfPlayers": 26
                   },
                   {
                     "name": "Manchester City",
                     "yearFounded": 1880,
                     "country": "England",
-                    "numberOfPlayers": "25"
+                    "numberOfPlayers": 25
                   },
                   {
                     "name": "Sunderland",
                     "yearFounded": 1879,
                     "country": "England",
-                    "numberOfPlayers": "30"
+                    "numberOfPlayers": 30
                   }
                 ]
                 """;

--- a/json-csharp/HowToSerializeAListToJsonInCSharp/Tests/SystemTextJsonMethodsTests.cs
+++ b/json-csharp/HowToSerializeAListToJsonInCSharp/Tests/SystemTextJsonMethodsTests.cs
@@ -1,4 +1,5 @@
-﻿using HowToSerializeAListToJsonInCSharp;
+﻿using System.Text;
+using HowToSerializeAListToJsonInCSharp;
 
 namespace Tests
 {
@@ -11,21 +12,21 @@ namespace Tests
                     Name = "Arsenal",
                     YearFounded = 1886,
                     Country = "England",
-                    NumberOfPlayers = "26",
+                    NumberOfPlayers = 26,
                 },
                 new Club
                 {
                     Name = "Manchester City",
                     YearFounded = 1880,
                     Country = "England",
-                    NumberOfPlayers = "25",
+                    NumberOfPlayers = 25,
                 },
                 new Club
                 {
                     Name = "Sunderland",
                     YearFounded = 1879,
                     Country = "England",
-                    NumberOfPlayers = "30",
+                    NumberOfPlayers = 30,
                 }
             };
 
@@ -39,19 +40,19 @@ namespace Tests
                     "name": "Arsenal",
                     "yearFounded": 1886,
                     "country": "England",
-                    "numberOfPlayers": "26"
+                    "numberOfPlayers": 26
                   },
                   {
                     "name": "Manchester City",
                     "yearFounded": 1880,
                     "country": "England",
-                    "numberOfPlayers": "25"
+                    "numberOfPlayers": 25
                   },
                   {
                     "name": "Sunderland",
                     "yearFounded": 1879,
                     "country": "England",
-                    "numberOfPlayers": "30"
+                    "numberOfPlayers": 30
                   }
                 ]
                 """;
@@ -69,6 +70,17 @@ namespace Tests
         {
             var englishClubsJson = _serializeList.SerializeToUtf8BytesMethod();
 
+            Assert.Equal(_expectedResult, englishClubsJson);
+        }
+
+        [Fact]
+        public async Task GivenAList_WhenUsingTheSerializeToStreamAsyncMethod_ThenWritesAJsonStringToTheStream()
+        {
+            using var stream = new MemoryStream();
+
+            await _serializeList.SerializeToStreamAsync(stream);
+
+            var englishClubsJson = Encoding.UTF8.GetString(stream.ToArray());
             Assert.Equal(_expectedResult, englishClubsJson);
         }
     }

--- a/json-csharp/HowToSerializeAListToJsonInCSharp/Tests/Tests.csproj
+++ b/json-csharp/HowToSerializeAListToJsonInCSharp/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Sample update for **How to Serialize a List to JSON in C#** (`json-csharp/HowToSerializeAListToJsonInCSharp`).

### What changed

- **Both projects retargeted `net7.0` -> `net10.0`.** net7.0 is out of support.
- **Packages bumped** (versions read from NuGet on the day, not from memory): `BenchmarkDotNet` 0.13.5 -> 0.15.8, `Newtonsoft.Json` 13.0.2 -> 13.0.4, `Microsoft.NET.Test.Sdk` 17.3.2 -> 18.9.0, `xunit` 2.4.2 -> 2.9.3, `xunit.runner.visualstudio` 2.4.5 -> 4.0.0, `coverlet.collector` 3.1.2 -> 10.0.1.
- **New `SerializeToStreamAsync(Stream)`** on `SerializeListToJsonWithSystemTextJson`, calling `JsonSerializer.SerializeAsync(stream, clubList, _options)`, plus one test asserting the stream's contents match the expected JSON. The article gains a section on writing a list straight to a file or a stream, and this is the code behind it.
- **`Club.NumberOfPlayers` is now an `int`.** It was a `string` holding `"26"`, so every JSON sample on the page printed `"numberOfPlayers": "26"` in quotes next to a bare `"yearFounded": 1886` - in an article about turning C# objects into JSON. Both test expectation strings updated with it.
- **Primary constructors** on the two serializer classes, and `Program.cs` lifted to top-level statements.

### Verification

- `dotnet build -c Release`: **0 warnings, 0 errors** on SDK **10.0.302** (runtime 10.0.10).
- `dotnet test -c Release`: **5/5 passed** (4 existing + the new stream test).
- Benchmark re-run on net10.0. The published table's row labels never matched the `[Benchmark]` method names, so the article's console block is being replaced with the real output:

```
| Method                                   | Mean     | Error     | StdDev    | Allocated |
|----------------------------------------- |---------:|----------:|----------:|----------:|
| SystemTextJsonSerializeMethod            | 3.297 ms | 0.0560 ms | 0.0496 ms |   2.23 MB |
| SystemTextJsonSerializeToUtf8BytesMethod | 3.404 ms | 0.0668 ms | 0.0769 ms |   3.35 MB |
| NewtonsoftJsonJsonSerializerClass        | 4.739 ms | 0.0716 ms | 0.0635 ms |   4.95 MB |
| NewtonsoftJsonSerializeObjectMethod      | 4.800 ms | 0.0545 ms | 0.0509 ms |   4.94 MB |
```

The ordering the article states still holds on .NET 10: both `System.Text.Json` methods finish ahead of both `Newtonsoft.Json` methods, and `Serialize()` finishes ahead of `SerializeToUtf8Bytes()`.