### PR TITLE
Serialize enum as string: net10.0, ConfigureHttpJsonOptions, DataContractJsonSerializer and source-generation samples

### DIFF
--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.EnumAsString.Models/JsonSerialization.EnumAsString.Models.csproj
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.EnumAsString.Models/JsonSerialization.EnumAsString.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.MinimalApi/JsonSerialization.Native.EnumAsString.MinimalApi.csproj
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.MinimalApi/JsonSerialization.Native.EnumAsString.MinimalApi.csproj
@@ -1,14 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
-  </ItemGroup>
   <ItemGroup>
 	<InternalsVisibleTo Include="JsonSerialization.Native.EnumAsString.MinimalApiTests" />
   </ItemGroup>

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.MinimalApi/Program.cs
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.MinimalApi/Program.cs
@@ -1,9 +1,8 @@
 using JsonSerialization.EnumAsString.Models;
-using Microsoft.AspNetCore.Http.Json;
 using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.Configure<JsonOptions>(options =>
+builder.Services.ConfigureHttpJsonOptions(options =>
 {
     options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
 });

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.MinimalApiTests/JsonSerialization.Native.EnumAsString.MinimalApiTests.csproj
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.MinimalApiTests/JsonSerialization.Native.EnumAsString.MinimalApiTests.csproj
@@ -1,21 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.WebApi/JsonSerialization.Native.EnumAsString.WebApi.csproj
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.WebApi/JsonSerialization.Native.EnumAsString.WebApi.csproj
@@ -1,15 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>	
   <ItemGroup>
 	<InternalsVisibleTo Include="JsonSerialization.Native.EnumAsStringTests" />
-  </ItemGroup>	
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>	
   <ItemGroup>
     <ProjectReference Include="..\JsonSerialization.EnumAsString.Models\JsonSerialization.EnumAsString.Models.csproj" />

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.WebApi/Program.cs
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsString.WebApi/Program.cs
@@ -10,8 +10,6 @@ builder.Services.AddControllers()
 
 var app = builder.Build();
 
-app.UseAuthorization();
-
 app.MapControllers();
 
 app.Run();

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/CustomNames/ToggleControl.cs
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/CustomNames/ToggleControl.cs
@@ -1,0 +1,15 @@
+namespace JsonSerialization.Native.EnumAsStringTests.CustomNames;
+
+public record struct ToggleControl(string Name, ToggleType Type);
+
+public enum ToggleType
+{
+    [JsonStringEnumMemberName("Enable/Disable")]
+    EnableDisable,
+
+    [JsonStringEnumMemberName("Visible/Hidden")]
+    VisibleHidden,
+
+    [JsonStringEnumMemberName("Editable/Readonly")]
+    EditableReadonly,
+}

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/CustomSerializationUnitTest.cs
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/CustomSerializationUnitTest.cs
@@ -41,4 +41,28 @@ public class CustomSerializationUnitTest : UnitTestBase
 
         Assert.Equal("[{\"Name\":\"toggle1\",\"Type\":\"EnableDisable\"},{\"Name\":\"toggle2\",\"Type\":\"VisibleHidden\"}]", json);
     }
+
+    [Fact]
+    public void GivenEnum_WhenDecoratedWithJsonStringEnumMemberName_ThenSerializeAsSpecifiedString()
+    {
+        var controls = new CustomNames.ToggleControl[]
+        {
+            new("toggle1", CustomNames.ToggleType.EnableDisable),
+            new("toggle2", CustomNames.ToggleType.VisibleHidden)
+        };
+
+        var json = SerializeWithStringEnum(controls);
+
+        Assert.Equal("[{\"Name\":\"toggle1\",\"Type\":\"Enable/Disable\"},{\"Name\":\"toggle2\",\"Type\":\"Visible/Hidden\"}]", json);
+    }
+
+    [Fact]
+    public void GivenEnum_WhenDecoratedWithJsonStringEnumMemberNameButNoConverterRegistered_ThenSerializeAsNumber()
+    {
+        var control = new CustomNames.ToggleControl("toggle1", CustomNames.ToggleType.EnableDisable);
+
+        var json = Serialize(control);
+
+        Assert.Equal("{\"Name\":\"toggle1\",\"Type\":0}", json);
+    }
 }

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/DataContract/DataContractJsonSerializationUnitTest.cs
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/DataContract/DataContractJsonSerializationUnitTest.cs
@@ -1,0 +1,81 @@
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+namespace JsonSerialization.Native.EnumAsStringTests.DataContract;
+
+public class DataContractJsonSerializationUnitTest
+{
+    private static string SerializeToJson(ToggleSet set)
+    {
+        var serializer = new DataContractJsonSerializer(typeof(ToggleSet));
+
+        using var stream = new MemoryStream();
+        serializer.WriteObject(stream, set);
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static ToggleSet? DeserializeFromJson(string json)
+    {
+        var serializer = new DataContractJsonSerializer(typeof(ToggleSet));
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        return serializer.ReadObject(stream) as ToggleSet;
+    }
+
+    [Fact]
+    public void GivenEnum_WhenSerializedWithDataContractJsonSerializer_ThenWritesNumbersAndIgnoresEnumMember()
+    {
+        var set = new ToggleSet
+        {
+            Decorated = ToggleState.EnableDisable,
+            Undecorated = ToggleState.VisibleHidden
+        };
+
+        var json = SerializeToJson(set);
+
+        Assert.Equal("{\"Decorated\":0,\"Undecorated\":1}", json);
+    }
+
+    [Fact]
+    public void GivenEnumMemberString_WhenDeserializedWithDataContractJsonSerializer_ThenThrows()
+    {
+        var json = "{\"Decorated\":\"Enable/Disable\",\"Undecorated\":1}";
+
+        var exception = Assert.Throws<SerializationException>(() => DeserializeFromJson(json));
+
+        Assert.Contains("cannot be parsed as the type 'Int64'", exception.Message);
+    }
+
+    [Fact]
+    public void GivenUndefinedNumber_WhenDeserializedWithDataContractJsonSerializer_ThenAcceptsIt()
+    {
+        var json = "{\"Decorated\":42,\"Undecorated\":1}";
+
+        var set = DeserializeFromJson(json);
+
+        Assert.NotNull(set);
+        Assert.Equal(42, (int)set.Decorated);
+    }
+
+    [Fact]
+    public void GivenSameEnum_WhenSerializedWithXmlDataContractSerializer_ThenHonoursEnumMember()
+    {
+        var set = new ToggleSet
+        {
+            Decorated = ToggleState.EnableDisable,
+            Undecorated = ToggleState.VisibleHidden
+        };
+        var serializer = new DataContractSerializer(typeof(ToggleSet));
+
+        using var stream = new MemoryStream();
+        serializer.WriteObject(stream, set);
+        var xml = Encoding.UTF8.GetString(stream.ToArray());
+
+        Assert.Contains("<Decorated>Enable/Disable</Decorated>", xml);
+        Assert.Contains("<Undecorated>Visible/Hidden</Undecorated>", xml);
+    }
+}

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/DataContract/ToggleState.cs
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/DataContract/ToggleState.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Serialization;
+
+namespace JsonSerialization.Native.EnumAsStringTests.DataContract;
+
+[DataContract]
+public class ToggleSet
+{
+    [DataMember]
+    public ToggleState Decorated { get; set; }
+
+    [DataMember]
+    public ToggleState Undecorated { get; set; }
+}
+
+[DataContract]
+public enum ToggleState
+{
+    [EnumMember(Value = "Enable/Disable")]
+    EnableDisable = 0,
+
+    [EnumMember(Value = "Visible/Hidden")]
+    VisibleHidden = 1,
+}

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/JsonSerialization.Native.EnumAsStringTests.csproj
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/JsonSerialization.Native.EnumAsStringTests.csproj
@@ -1,21 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/SourceGeneration/CanvasContext.cs
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/SourceGeneration/CanvasContext.cs
@@ -1,0 +1,7 @@
+using JsonSerialization.EnumAsString.Models;
+
+namespace JsonSerialization.Native.EnumAsStringTests.SourceGeneration;
+
+[JsonSourceGenerationOptions(UseStringEnumConverter = true)]
+[JsonSerializable(typeof(Canvas))]
+internal partial class CanvasContext : JsonSerializerContext;

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/SourceGeneration/SourceGenerationUnitTest.cs
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Native.EnumAsStringTests/SourceGeneration/SourceGenerationUnitTest.cs
@@ -1,0 +1,14 @@
+using JsonSerialization.EnumAsString.Models;
+
+namespace JsonSerialization.Native.EnumAsStringTests.SourceGeneration;
+
+public class SourceGenerationUnitTest
+{
+    [Fact]
+    public void GivenSourceGeneratedContext_WhenUseStringEnumConverterIsSet_ThenSerializeAllEnumsAsString()
+    {
+        var json = JsonSerializer.Serialize(Canvas.Poster, CanvasContext.Default.Canvas);
+
+        Assert.Equal("{\"Name\":\"Poster\",\"BackColor\":\"LightGray\",\"Medium\":\"Water\",\"Pen\":{\"Name\":\"Simple\",\"Color\":\"Red\"}}", json);
+    }
+}

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Newtonsoft.EnumAsString.WebApi/JsonSerialization.Newtonsoft.EnumAsString.WebApi.csproj
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Newtonsoft.EnumAsString.WebApi/JsonSerialization.Newtonsoft.EnumAsString.WebApi.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
 	<InternalsVisibleTo Include="JsonSerialization.Newtonsoft.EnumAsStringTests" />

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Newtonsoft.EnumAsString.WebApi/Program.cs
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Newtonsoft.EnumAsString.WebApi/Program.cs
@@ -10,8 +10,6 @@ builder.Services.AddControllers()
 
 var app = builder.Build();
 
-app.UseAuthorization();
-
 app.MapControllers();
 
 app.Run();

--- a/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Newtonsoft.EnumAsStringTests/JsonSerialization.Newtonsoft.EnumAsStringTests.csproj
+++ b/json-csharp/JsonSerializationOfEnumAsString/JsonSerialization.Newtonsoft.EnumAsStringTests/JsonSerialization.Newtonsoft.EnumAsStringTests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Refresh of `json-csharp/JsonSerializationOfEnumAsString`, the sample behind [How to Serialize Enum to a String in C#](https://code-maze.com/csharp-serialize-enum-to-string/), which has not been touched since 2022.

**Target framework and packages**

All seven projects move from `net6.0` (out of support) to `net10.0`. Package versions were read from NuGet today, not from memory: `Newtonsoft.Json` 13.0.4, `Microsoft.AspNetCore.Mvc.NewtonsoftJson` 10.0.11, `Microsoft.AspNetCore.Mvc.Testing` 10.0.11, `Microsoft.NET.Test.Sdk` 18.9.0, `xunit` 2.9.3, `xunit.runner.visualstudio` 3.1.5, `coverlet.collector` 10.0.1. The runner stays on the 3.x line because 4.0.0 is the xUnit v3 line and this folder is on xUnit v2. The `System.Text.Json` package references are gone: the library is in-box on `net10.0`.

**Sample code**

- Minimal API: `builder.Services.Configure<JsonOptions>(...)` becomes `builder.Services.ConfigureHttpJsonOptions(...)`. Both configure the same `Microsoft.AspNetCore.Http.Json.JsonOptions` object; the extension is the current way to reach it, and it drops the `using Microsoft.AspNetCore.Http.Json;` directive.
- Both Web API samples called `app.UseAuthorization()` with no authentication or authorization registered anywhere in the solution. Removed.

**New tests**

- `[JsonStringEnumMemberName]` (.NET 9+): with a registered `JsonStringEnumConverter` the custom string is emitted, and without one the same model still writes a number. The attribute does nothing on its own, which is the trap worth covering.
- `DataContractJsonSerializer`: enums are always written as numbers, `[EnumMember]` is ignored, reading the string form back throws a `SerializationException`, a number no member defines is accepted, and the XML `DataContractSerializer` does honour `[EnumMember]` on the very same type. The class is in-box on `net10.0` and needs no package reference.
- Source-generated serialization through a `JsonSerializerContext` with `UseStringEnumConverter = true`, the AOT-safe form the `IL3050` analyzer points at.

The existing test asserting that `System.Text.Json` ignores `[EnumMember]` is kept unchanged: that behaviour is still current on .NET 10 and the article states it.

`dotnet build -c Release`: 0 errors, 0 warnings. `dotnet test -c Release`: 27 passed, 0 failed (SDK 10.0.302, runtime 10.0.10).