### PR TITLE
Build a query string: retarget net10.0, safe UriBuilder helper, CS8620 fix

### DIFF
--- a/dotnet-querystrings/BuildQueryString/BooksAPI/BooksAPI.csproj
+++ b/dotnet-querystrings/BuildQueryString/BooksAPI/BooksAPI.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-querystrings/BuildQueryString/BuildQueryString/BooksApiService.cs
+++ b/dotnet-querystrings/BuildQueryString/BuildQueryString/BooksApiService.cs
@@ -61,7 +61,7 @@
 
         public async Task<string> GetWithQueryParamsUsingAddQueryStringMethod(string author, string language)
         {
-            var query = new Dictionary<string, string>
+            var query = new Dictionary<string, string?>
             {
                 { "author", author },
                 { "language", language }
@@ -83,7 +83,7 @@
 
         public async Task<string> GetWithQueryParamsUsingCreateMethod(string author, string language)
         {
-            var query = new Dictionary<string, string>
+            var query = new Dictionary<string, string?>
             {
                 { "author", author },
                 { "language", language }

--- a/dotnet-querystrings/BuildQueryString/BuildQueryString/BuildQueryString.csproj
+++ b/dotnet-querystrings/BuildQueryString/BuildQueryString/BuildQueryString.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-	<FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-querystrings/BuildQueryString/BuildQueryString/Program.cs
+++ b/dotnet-querystrings/BuildQueryString/BuildQueryString/Program.cs
@@ -1,35 +1,27 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using BuildQueryString;
+using Microsoft.Extensions.DependencyInjection;
 
-namespace BuildQueryString
-{
-    public class Program
-    {
-        static async Task Main(string[] args)
-        {
-            var serviceProvider = new ServiceCollection()
-            .AddTransient<IHttpClientWrapper, HttpClientWrapper>()
-            .AddTransient<BooksApiService>()
-            .BuildServiceProvider();
+var serviceProvider = new ServiceCollection()
+    .AddTransient<IHttpClientWrapper, HttpClientWrapper>()
+    .AddTransient<BooksApiService>()
+    .BuildServiceProvider();
 
-            var booksService = serviceProvider.GetRequiredService<BooksApiService>();
+var booksService = serviceProvider.GetRequiredService<BooksApiService>();
 
-            Console.WriteLine("\n***************** Build the Query String Using StringConcatenation ***************\n");
-            Console.WriteLine(await booksService.GetWithQueryParamsUsingStringConcatenation("George Orwell", "english"));
+Console.WriteLine("\n***************** Build the Query String Using StringConcatenation ***************\n");
+Console.WriteLine(await booksService.GetWithQueryParamsUsingStringConcatenation("George Orwell", "english"));
 
-            Console.WriteLine("\n***************** Build the Query String Using UriBuilder Class ***************\n");
-            Console.WriteLine(await booksService.GetWithQueryParamsUsingUriBuilder("Jane Austen", "english"));
+Console.WriteLine("\n***************** Build the Query String Using UriBuilder Class ***************\n");
+Console.WriteLine(await booksService.GetWithQueryParamsUsingUriBuilder("Jane Austen", "english"));
 
-            Console.WriteLine("\n***************** Build the Query String Using ParseQueryString Method ***************\n");
-            Console.WriteLine(await booksService.GetWithQueryParamsUsingParseQueryStringMethod("Agatha Christie", "english"));
+Console.WriteLine("\n***************** Build the Query String Using ParseQueryString Method ***************\n");
+Console.WriteLine(await booksService.GetWithQueryParamsUsingParseQueryStringMethod("Agatha Christie", "english"));
 
-            Console.WriteLine("\n***************** Build the Query String Using AddQueryString Method ***************\n");
-            Console.WriteLine(await booksService.GetWithQueryParamsUsingAddQueryStringMethod("Haruki Murakami", "japanese"));
+Console.WriteLine("\n***************** Build the Query String Using AddQueryString Method ***************\n");
+Console.WriteLine(await booksService.GetWithQueryParamsUsingAddQueryStringMethod("Haruki Murakami", "japanese"));
 
-            Console.WriteLine("\n***************** Build the Query String Using QueryBuilder Class ***************\n");
-            Console.WriteLine(await booksService.GetWithQueryParamsUsingQueryBuilderClass("Gabriel Garcia", "spanish"));
+Console.WriteLine("\n***************** Build the Query String Using QueryBuilder Class ***************\n");
+Console.WriteLine(await booksService.GetWithQueryParamsUsingQueryBuilderClass("Gabriel Garcia", "spanish"));
 
-            Console.WriteLine("\n***************** Build the Query String Using QueryString Create Method ***************\n");
-            Console.WriteLine(await booksService.GetWithQueryParamsUsingCreateMethod("Leo Tolstoy", "russian"));
-        }
-    }
-}
+Console.WriteLine("\n***************** Build the Query String Using QueryString Create Method ***************\n");
+Console.WriteLine(await booksService.GetWithQueryParamsUsingCreateMethod("Leo Tolstoy", "russian"));

--- a/dotnet-querystrings/BuildQueryString/BuildQueryString/QueryStringHelper.cs
+++ b/dotnet-querystrings/BuildQueryString/BuildQueryString/QueryStringHelper.cs
@@ -31,6 +31,20 @@ namespace BuildQueryString
             return fullApiUrl;
         }
 
+        public static string BuildUrlWithQueryStringUsingUriBuilderSafely(
+            string basePath, Dictionary<string, string?> queryParams)
+        {
+            var uriBuilder = new UriBuilder(basePath)
+            {
+                Query = QueryString.Create(queryParams).Value
+            };
+
+            var fullApiUrl = uriBuilder.Uri.AbsoluteUri;
+            Console.WriteLine($"Full API Url: {fullApiUrl}");
+
+            return fullApiUrl;
+        }
+
         public static string BuildUrlWithQueryStringUsingParseQueryStringMethod(
             string basePath, Dictionary<string, string> queryParams)
         {

--- a/dotnet-querystrings/BuildQueryString/BuildQueryStringTests/BuildQueryStringUnitTests.csproj
+++ b/dotnet-querystrings/BuildQueryString/BuildQueryStringTests/BuildQueryStringUnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet-querystrings/BuildQueryString/BuildQueryStringTests/QueryStringHelperUnitTests.cs
+++ b/dotnet-querystrings/BuildQueryString/BuildQueryStringTests/QueryStringHelperUnitTests.cs
@@ -1,4 +1,5 @@
 using BuildQueryString;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace BuildQueryStringTests
@@ -49,6 +50,28 @@ namespace BuildQueryStringTests
         }
 
         [TestMethod]
+        public void GivenValuesWithQueryDelimiters_WhenBuildUrlWithQueryStringUsingUriBuilderSafely_ThenValuesRoundTrip()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string?>
+            {
+                { "author", "Tom & Jerry" },
+                { "tag", "C#" }
+            };
+            var expectedApiUrl = "https://localhost:7220/api/Books?author=Tom%20%26%20Jerry&tag=C%23";
+
+            // Act
+            var result = QueryStringHelper.BuildUrlWithQueryStringUsingUriBuilderSafely(basePath, dict);
+
+            //Assert
+            Assert.AreEqual(expectedApiUrl, result);
+
+            var parsed = QueryHelpers.ParseQuery(new Uri(result).Query);
+            Assert.AreEqual("Tom & Jerry", parsed["author"].ToString());
+            Assert.AreEqual("C#", parsed["tag"].ToString());
+        }
+
+        [TestMethod]
         public void GivenBasePathAndQueryParams_WhenBuildUrlWithQueryStringUsingParseQueryStringMethod_ThenCorrectApiUrlIsBuilt()
         {
             // Arrange
@@ -74,7 +97,7 @@ namespace BuildQueryStringTests
             // Arrange
             var author = "Haruki Murakami";
             var language = "japanese";
-            var dict = new Dictionary<string, string>
+            var dict = new Dictionary<string, string?>
             {
                 { "author", author },
                 { "language", language }
@@ -114,7 +137,7 @@ namespace BuildQueryStringTests
             // Arrange
             var author = "Leo Tolstoy";
             var language = "russian";
-            var dict = new Dictionary<string, string>
+            var dict = new Dictionary<string, string?>
             {
                 { "author", author },
                 { "language", language }


### PR DESCRIPTION
Updates the `dotnet-querystrings/BuildQueryString` sample for the republish of [How to Build a Query String for a URL in C#](https://code-maze.com/how-to-create-a-url-query-string/).

### Retarget

`net7.0` -> `net10.0` on all three projects (`BuildQueryString`, `BuildQueryStringTests`, `BooksAPI`). Package versions taken from the NuGet flat-container index on 2026-08-30, not from memory:

| Package | Was | Now |
|---|---|---|
| Microsoft.Extensions.DependencyInjection | 7.0.0 | 10.0.11 |
| Microsoft.NET.Test.Sdk | 17.5.0 | 18.9.0 |
| MSTest.TestAdapter / MSTest.TestFramework | 2.2.10 | 4.3.3 |
| Moq | 4.20.69 | 4.20.72 |
| coverlet.collector | 3.2.0 | 10.0.1 |
| Swashbuckle.AspNetCore | 6.2.3 | 10.2.3 |

The MSTest 2.x -> 4.x jump needed no source changes: the classic `Assert.AreEqual` / `TestClass` / `TestMethod` API compiles as-is and no MSTEST analyzer diagnostic fires in this folder.

### Safe `UriBuilder` composition (new helper + test)

The article's central claim about `UriBuilder` was wrong: it escapes characters that are illegal anywhere in a URI, but it does not escape the query delimiters `&`, `=` and `#` inside a value. Assigning `author=Tom & Jerry` to `Query` yields `?author=Tom%20&%20Jerry`, which a receiver parses as two parameters, the second named ` Jerry`.

`BuildUrlWithQueryStringUsingUriBuilderSafely` is the one-line composition that does encode: build the query with `QueryString.Create` and hand the finished string to `UriBuilder`. The new test asserts the full round trip over `Tom & Jerry` and `C#`:

```
https://localhost:7220/api/Books?author=Tom%20%26%20Jerry&tag=C%23
```

parsed back to `author` = `Tom & Jerry` and `tag` = `C#`.

### CS8620

`BuildUrlWithQueryStringUsingAddQueryStringMethod` and `BuildUrlWithQueryStringUsingCreateMethod` take `Dictionary<string, string?>`, and every caller declared `Dictionary<string, string>`, which warns:

```
warning CS8620: Argument of type 'Dictionary<string, string>' cannot be used for parameter 'queryParams'
of type 'Dictionary<string, string?>' ... due to differences in the nullability of reference types
```

Fixed at all four call sites (two in `BooksApiService`, two in `QueryStringHelperUnitTests`). The build is now warning-clean apart from NU1510 on the DI package, which the article tells the reader to install explicitly.

### Idiom

`BuildQueryString/Program.cs` lifted to top-level statements. `BooksAPI/Program.cs` was read and already uses minimal `WebApplication` hosting with no `Startup.cs`, so it is untouched.

### Build and tests

```
dotnet build BuildQueryString.sln -c Release   ->  Build succeeded, 0 errors
dotnet test  BuildQueryString.sln -c Release   ->  Passed! - Failed: 0, Passed: 14, Skipped: 0, Total: 14
```

13 pre-existing tests plus the one added. Every comparison-table cell in the article was re-produced by running the retargeted solution itself on .NET 10.0.10, not by reading reference pages.
