### PR TITLE
ConcurrentQueue in C#: retarget net10.0, fix non-deterministic consumer, cover every member

### DIFF
--- a/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/ConcurrentQueueInCSharp.csproj
+++ b/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/ConcurrentQueueInCSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/Consumer.cs
+++ b/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/Consumer.cs
@@ -1,21 +1,21 @@
-﻿public class Consumer
+﻿public class Consumer(OrderMessageBus messageBus)
 {
-    private readonly OrderMessageBus _messageBus;
-
-    public Consumer(OrderMessageBus messageBus)
+    public Task Process(CancellationToken token)
     {
-        _messageBus = messageBus;
-    }
-
-    public Task Process()
-    {
-        return Task.Run(() =>
+        return Task.Run(async () =>
         {
-            while (_messageBus.Fetch(out var order))
+            while (!token.IsCancellationRequested)
             {
-                Console.WriteLine($"ProcessId {Task.CurrentId} | Processing order {order.Id}");
-                Thread.Sleep(200);
+                if (messageBus.Fetch(out var order))
+                {
+                    Console.WriteLine($"ProcessId {Task.CurrentId} | Processing order {order!.Id}");
+                    Thread.Sleep(200);
+                }
+                else
+                {
+                    await Task.Delay(50, CancellationToken.None);
+                }
             }
-        });
+        }, CancellationToken.None);
     }
 }

--- a/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/Models/Order.cs
+++ b/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/Models/Order.cs
@@ -2,6 +2,6 @@
 {
     public class Order
     {
-        public string Id { get; init; }
+        public required string Id { get; init; }
     }
 }

--- a/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/Producer.cs
+++ b/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/Producer.cs
@@ -1,23 +1,14 @@
 ﻿using ConcurrentQueueInCSharp.Models;
 
-public class Producer
+public class Producer(OrderMessageBus messageBus, int numberOfMessages)
 {
-    private readonly OrderMessageBus _messageBus;
-    private readonly int _numberOfMessages;
-
-    public Producer(OrderMessageBus messageBus, int numberOfMessages)
-    {
-        _messageBus = messageBus;
-        _numberOfMessages = numberOfMessages;
-    }
-
     public Task Produce()
     {
         return Task.Run(() =>
         {
-            for (int i = 0; i < _numberOfMessages; i++)
+            for (int i = 0; i < numberOfMessages; i++)
             {
-                _messageBus.Add(new Order { Id = Guid.NewGuid().ToString() });
+                messageBus.Add(new Order { Id = Guid.NewGuid().ToString() });
             }
         });
     }

--- a/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/Program.cs
+++ b/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharp.Console/Program.cs
@@ -4,10 +4,23 @@ var producer1 = new Producer(messageBus, 10);
 var producer2 = new Producer(messageBus, 10);
 var producer3 = new Producer(messageBus, 10);
 
+var cancellation = new CancellationTokenSource();
+
 var consumer1 = new Consumer(messageBus);
 var consumer2 = new Consumer(messageBus);
 var consumer3 = new Consumer(messageBus);
-            
-Task.WaitAll(
-    producer1.Produce(), producer2.Produce(), producer3.Produce(), 
-    consumer1.Process(), consumer2.Process(), consumer3.Process());
+
+var consumers = Task.WhenAll(
+    consumer1.Process(cancellation.Token),
+    consumer2.Process(cancellation.Token),
+    consumer3.Process(cancellation.Token));
+
+await Task.WhenAll(producer1.Produce(), producer2.Produce(), producer3.Produce());
+
+while (messageBus.Count > 0)
+{
+    await Task.Delay(50);
+}
+
+await cancellation.CancelAsync();
+await consumers;

--- a/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharpTests/ConcurrentQueueInCSharpTests.csproj
+++ b/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharpTests/ConcurrentQueueInCSharpTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharpTests/ConcurrentQueueMemberTests.cs
+++ b/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharpTests/ConcurrentQueueMemberTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Concurrent;
+
+namespace ConcurrentQueueInCSharpTests
+{
+    public class ConcurrentQueueMemberTests
+    {
+        [Test]
+        public void WhenEnqueueingItems_ThenTheyComeBackInOrder()
+        {
+            ConcurrentQueue<int> queue = new();
+
+            queue.Enqueue(1);
+            queue.Enqueue(2);
+
+            Assert.That(queue.TryDequeue(out var first), Is.True);
+            Assert.That(first, Is.EqualTo(1));
+            Assert.That(queue.TryDequeue(out var second), Is.True);
+            Assert.That(second, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void WhenSeedingFromEnumerable_ThenItemsKeepTheirOrder()
+        {
+            ConcurrentQueue<int> queue = new([1, 2, 3]);
+
+            Assert.That(queue.ToArray(), Is.EqualTo(new[] { 1, 2, 3 }));
+        }
+
+        [Test]
+        public void WhenDequeueingFromEmptyQueue_ThenItReturnsFalseInsteadOfThrowing()
+        {
+            ConcurrentQueue<int> queue = new();
+
+            Assert.That(queue.TryDequeue(out var item), Is.False);
+            Assert.That(item, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void WhenPeeking_ThenTheItemStaysInTheQueue()
+        {
+            ConcurrentQueue<int> queue = new();
+            queue.Enqueue(42);
+
+            Assert.That(queue.TryPeek(out var peeked), Is.True);
+            Assert.That(peeked, Is.EqualTo(42));
+            Assert.That(queue.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void WhenPeekingAnEmptyQueue_ThenItReturnsFalseInsteadOfThrowing()
+        {
+            ConcurrentQueue<int> queue = new();
+
+            Assert.That(queue.TryPeek(out _), Is.False);
+        }
+
+        [Test]
+        public void WhenQueueHoldsNoItems_ThenIsEmptyIsTrue()
+        {
+            ConcurrentQueue<int> queue = new();
+
+            Assert.That(queue.IsEmpty, Is.True);
+
+            queue.Enqueue(1);
+
+            Assert.That(queue.IsEmpty, Is.False);
+        }
+
+        [Test]
+        public void WhenClearing_ThenTheQueueIsEmpty()
+        {
+            ConcurrentQueue<int> queue = new([1, 2, 3]);
+
+            queue.Clear();
+
+            Assert.That(queue.IsEmpty, Is.True);
+            Assert.That(queue.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void WhenCopyingTo_ThenTheTargetArrayHoldsASnapshot()
+        {
+            ConcurrentQueue<int> queue = new([1, 2, 3]);
+            var target = new int[3];
+
+            queue.CopyTo(target, 0);
+            queue.Enqueue(4);
+
+            Assert.That(target, Is.EqualTo(new[] { 1, 2, 3 }));
+        }
+
+        [Test]
+        public void WhenEnumerating_ThenLaterEnqueuesAreInvisibleToTheLoop()
+        {
+            ConcurrentQueue<int> queue = new([1, 2]);
+            var seen = new List<int>();
+
+            var enumerator = queue.GetEnumerator();
+            queue.Enqueue(3);
+
+            while (enumerator.MoveNext())
+            {
+                seen.Add(enumerator.Current);
+            }
+
+            Assert.That(seen, Is.EqualTo(new List<int> { 1, 2 }));
+        }
+
+        [Test]
+        public void WhenLookingForContains_ThenTheTypeDoesNotDeclareIt()
+        {
+            var contains = typeof(ConcurrentQueue<int>).GetMethod("Contains");
+
+            Assert.That(contains, Is.Null);
+            Assert.That(new ConcurrentQueue<int>([1, 2, 3]).Any(item => item == 2), Is.True);
+        }
+    }
+}

--- a/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharpTests/MessageBusTests.cs
+++ b/collections-csharp/ConcurrentQueueInCSharp/ConcurrentQueueInCSharpTests/MessageBusTests.cs
@@ -1,17 +1,10 @@
-using ConcurrentQueueInCSharp;
 using ConcurrentQueueInCSharp.Models;
 
 namespace ConcurrentQueueInCSharpTests
 {
     public class MessageBusTests
     {
-        private OrderMessageBus _messageBus;
-
-        [SetUp]
-        public void Setup()
-        {
-            _messageBus = new OrderMessageBus();
-        }
+        private readonly OrderMessageBus _messageBus = new();
 
         [Test]
         public void WhenAddingNewOrder_ThenOrderIsStoredInQueue()


### PR DESCRIPTION
Updates the `collections-csharp/ConcurrentQueueInCSharp` sample for the ConcurrentQueue article refresh.

- Retargets both projects from `net7.0` (out of support) to `net10.0`.
- Bumps the test packages, including NUnit 3 to 4: `Microsoft.NET.Test.Sdk` 18.9.0, `NUnit` 4.6.1, `NUnit3TestAdapter` 6.3.0, `NUnit.Analyzers` 4.14.0, `coverlet.collector` 10.0.1. The existing tests already used the constraint model, so no assertion rewrites were needed.
- `Order.Id` becomes `required`, which clears CS8618 under `<Nullable>enable</Nullable>`.
- **Fixes a real non-determinism bug.** `Consumer.Process()` looped on `while (_messageBus.Fetch(out var order))`, and `Program.cs` started three producers and three consumers together under one `Task.WaitAll`. A consumer scheduled before any producer enqueued anything saw `false` on its first `Fetch` and terminated, so the demo processed an arbitrary subset of the orders on every run and sometimes processed none. `Consumer` now takes a `CancellationToken` and waits on the empty path; `Program.cs` cancels once the producers have finished and the queue has drained. Three consecutive runs now each process all 30 orders.
- Primary constructors on `Producer` and `Consumer`.
- Renames `ProducerTests.cs` to `MessageBusTests.cs` (it contains `MessageBusTests` and no producer test) and initialises the bus on the field instead of `[SetUp]` alone.
- Adds `ConcurrentQueueMemberTests`, covering `Enqueue`, `TryDequeue`, `TryPeek`, `IsEmpty`, `Count`, `Clear`, `ToArray`, `CopyTo`, snapshot enumeration, and the absence of a `Contains` method, so every row of the article's new member table is backed by a passing test.

`dotnet build -c Release`: 0 warnings, 0 errors. `dotnet test`: 13 passed, 0 failed. SDK 10.0.302.
