### PR TITLE
Filtered Include: retarget net10.0, EF Core 10.0.11, add Assignment entity

### DIFF
--- a/.github/ci-skip-folders.txt
+++ b/.github/ci-skip-folders.txt
@@ -9,6 +9,7 @@
 dotnet-efcore/TestForValidDbConnection
 dotnet-efcore/OptimisticVsPessimisticLocking
 dotnet-efcore/EfCoreInterceptors
+dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore
 
 # docker-compose-dependent: needs external infra (Kafka / OTel collector) the
 # runner doesn't provide.

--- a/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/FilteringResultsInsideInclude.csproj
+++ b/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/FilteringResultsInsideInclude.csproj
@@ -2,19 +2,19 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Migrations/20260907111628_AddAssignment.Designer.cs
+++ b/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Migrations/20260907111628_AddAssignment.Designer.cs
@@ -3,6 +3,7 @@ using FilteringResultsInsideInclude.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FilteringResultsInsideInclude.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260907111628_AddAssignment")]
+    partial class AddAssignment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Migrations/20260907111628_AddAssignment.cs
+++ b/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Migrations/20260907111628_AddAssignment.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FilteringResultsInsideInclude.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAssignment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Assignments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    StudentId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Assignments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Assignments_Students_StudentId",
+                        column: x => x.StudentId,
+                        principalTable: "Students",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Assignments_StudentId",
+                table: "Assignments",
+                column: "StudentId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Assignments");
+        }
+    }
+}

--- a/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Models/AppDbContext.cs
+++ b/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Models/AppDbContext.cs
@@ -6,10 +6,11 @@ namespace FilteringResultsInsideInclude.Models
     {
         public DbSet<Student>? Students { get; set; }
         public DbSet<Course>? Courses { get; set; }
+        public DbSet<Assignment>? Assignments { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=.;Database=AppDB;Trusted_Connection=True;");
+            optionsBuilder.UseSqlServer(@"Server=.;Database=AppDB;Trusted_Connection=True;TrustServerCertificate=True;");
         }
     }
 }

--- a/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Models/Assignment.cs
+++ b/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Models/Assignment.cs
@@ -1,0 +1,11 @@
+namespace FilteringResultsInsideInclude.Models
+{
+    public class Assignment
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+
+        public int StudentId { get; set; }
+        public Student? Student { get; set; }
+    }
+}

--- a/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Models/Student.cs
+++ b/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Models/Student.cs
@@ -8,5 +8,7 @@
 
         public int CourseId { get; set; }
         public Course? Course { get; set; }
+
+        public ICollection<Assignment>? Assignments { get; set; }
     }
 }

--- a/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Queries.cs
+++ b/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/FilteringResultsInsideInclude/Queries.cs
@@ -7,7 +7,8 @@ namespace FilteringResultsInsideInclude
     {
         public const int CourseCount = 10;
         public const int StudentCountPerCourse = 100;
-        
+        public const int AssignmentCountPerStudent = 2;
+
         public static async Task SeedData(AppDbContext context)
         {
             if (!context.Courses!.Any())
@@ -18,7 +19,11 @@ namespace FilteringResultsInsideInclude
                     Students = Enumerable.Range(1, StudentCountPerCourse).Select(j => new Student()
                     {
                         Name = $"Student {10 * i + j}",
-                        Mark = j
+                        Mark = j,
+                        Assignments = Enumerable.Range(1, AssignmentCountPerStudent).Select(k => new Assignment
+                        {
+                            Title = $"Assignment {k}"
+                        }).ToList()
                     }).ToList()
                 }).ToList();
 
@@ -50,6 +55,18 @@ namespace FilteringResultsInsideInclude
             var goodQuery = context.Courses!
                 .Include(c => c.Students!.Where(s => s.Mark > 50))
                 .Include(c => c.Students!.Where(s => s.Mark > 50))
+                .ToList();
+
+            return goodQuery;
+        }
+
+        public static List<Course> GoodFilteringOnMultipleIncludeWithThenInclude(AppDbContext context)
+        {
+            var goodQuery = context.Courses!
+                .Include(c => c.Students!.Where(s => s.Mark > 50))
+                    .ThenInclude(s => s.Assignments)
+                .Include(c => c.Students!)
+                    .ThenInclude(s => s.Assignments)
                 .ToList();
 
             return goodQuery;
@@ -98,7 +115,7 @@ namespace FilteringResultsInsideInclude
         public static List<Course> FilteringInsideIncludeAndSelectMethod(AppDbContext context)
         {
             var courses = context.Courses!
-                .Include(x => x.Students!.Where(x => x.Mark > 50))
+                .Include(c => c.Students!.Where(s => s.Mark > 50))
                 .Select(c => new Course 
                 { 
                     Id = c.Id,
@@ -120,6 +137,38 @@ namespace FilteringResultsInsideInclude
                 }).ToList();
 
             return courses;
+        }
+
+        public static List<Course> FilteredIncludeWithSortingAndPaging(AppDbContext context)
+        {
+            var topStudents = context.Courses!
+                .Include(c => c.Students!
+                    .Where(s => s.Mark > 50)
+                    .OrderByDescending(s => s.Mark)
+                    .Take(3))
+                .ToList();
+
+            return topStudents;
+        }
+
+        public static List<Course> FilteredIncludeWithoutMatchingStudents(AppDbContext context)
+        {
+            var courses = context.Courses!
+                .Include(c => c.Students!.Where(s => s.Mark > StudentCountPerCourse))
+                .ToList();
+
+            return courses;
+        }
+
+        public static List<Student> ExplicitLoadingWithFilter(AppDbContext context, Course course)
+        {
+            var students = context.Entry(course)
+                .Collection(c => c.Students!)
+                .Query()
+                .Where(s => s.Mark > 50)
+                .ToList();
+
+            return students;
         }
 
     }

--- a/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/Tests/FilteringResultInsideIncludeLiveTest.cs
+++ b/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/Tests/FilteringResultInsideIncludeLiveTest.cs
@@ -119,5 +119,53 @@ namespace Tests
             Assert.Equal(expected, actual.Select(x => x.Students).Sum(x => x!.Count));
         }
 
+        [Fact]
+        public void WhenUsingThenIncludeAfterAFilteredInclude_ThenTheLowerLevelInheritsTheNarrowedSet()
+        {
+            var context = new AppDbContext();
+            var actual = Queries.GoodFilteringOnMultipleIncludeWithThenInclude(context);
+
+            var expectedStudents = Queries.CourseCount * (Queries.StudentCountPerCourse / 2);
+            var expectedAssignments = expectedStudents * Queries.AssignmentCountPerStudent;
+
+            Assert.Equal(Queries.CourseCount, actual.Count);
+            Assert.Equal(expectedStudents, actual.Sum(x => x.Students!.Count));
+            Assert.Equal(expectedAssignments, actual.SelectMany(x => x.Students!).Sum(s => s.Assignments!.Count));
+        }
+
+        [Fact]
+        public void WhenSortingAndPagingInsideInclude_ThenTakeAppliesPerCourse()
+        {
+            var context = new AppDbContext();
+            var actual = Queries.FilteredIncludeWithSortingAndPaging(context);
+
+            Assert.Equal(Queries.CourseCount, actual.Count);
+            Assert.All(actual, course => Assert.Equal(3, course.Students!.Count));
+            Assert.Equal(Queries.CourseCount * 3, actual.Sum(x => x.Students!.Count));
+            Assert.All(actual, course => Assert.Equal(Queries.StudentCountPerCourse, course.Students!.First().Mark));
+        }
+
+        [Fact]
+        public void WhenNoStudentMatchesTheFilter_ThenTheCourseIsStillReturnedWithAnEmptyCollection()
+        {
+            var context = new AppDbContext();
+            var actual = Queries.FilteredIncludeWithoutMatchingStudents(context);
+
+            Assert.Equal(Queries.CourseCount, actual.Count);
+            Assert.All(actual, course => Assert.Empty(course.Students!));
+        }
+
+        [Fact]
+        public void WhenExplicitlyLoadingWithAFilter_ThenOnlyMatchingStudentsAreLoaded()
+        {
+            var context = new AppDbContext();
+            var course = context.Courses!.First();
+
+            var actual = Queries.ExplicitLoadingWithFilter(context, course);
+
+            Assert.Equal(Queries.StudentCountPerCourse / 2, actual.Count);
+            Assert.All(actual, student => Assert.True(student.Mark > 50));
+        }
+
     }
 }

--- a/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/Tests/Tests.csproj
+++ b/dotnet-efcore/FilteringResultsInsideTheIncludeMethodInEFCore/Tests/Tests.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Refreshes the sample behind https://code-maze.com/ef-core-filtered-include/.

- Both projects retargeted `net6.0` -> `net10.0`; the four EF Core packages `6.0.8` -> `10.0.11`; test packages to Microsoft.NET.Test.Sdk 18.9.0, xunit 2.9.3, xunit.runner.visualstudio 4.0.0, coverlet.collector 10.0.1.
- `TrustServerCertificate=True` added to the connection string. EF Core 10 loads Microsoft.Data.SqlClient 6.1.6, where `Encrypt` defaults to true and `TrustServerCertificate` to false, so the old string fails on the certificate chain after the retarget.
- New `Assignment` entity plus an `Assignments` collection on `Student`, with a migration and a seeding change, so the sample can show the documented multi-level `ThenInclude` form after a filtered `Include`.
- New query methods with tests: `GoodFilteringOnMultipleIncludeWithThenInclude`, `FilteredIncludeWithSortingAndPaging`, `FilteredIncludeWithoutMatchingStudents`, `ExplicitLoadingWithFilter`.
- Shadowed lambda parameters in `FilteringInsideIncludeAndSelectMethod` renamed to `c` and `s`.
- The folder joins `.github/ci-skip-folders.txt` beside its three EF Core siblings: every fact in `FilteringResultInsideIncludeLiveTest` needs a live SQL Server the runner does not have.

Verified locally on SQL Server LocalDB, SDK 10.0.302: build clean, **14 of 14 tests passed** on `net10.0`.