### PR TITLE
Replace line breaks: retarget net10.0, fix the regex, real mixed-ending fixture

### DIFF
--- a/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharp/Program.cs
+++ b/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharp/Program.cs
@@ -8,3 +8,6 @@ Console.WriteLine(stringReplaceLineEndingsResult);
 
 var regularExpressionReplaceResult = ReplaceLineBreak.ReplaceLineBreaksUsingTheRegularExpressionReplaceMethod();
 Console.WriteLine(regularExpressionReplaceResult);
+
+var removeLineBreaksResult = ReplaceLineBreak.RemoveLineBreaks();
+Console.WriteLine(removeLineBreaksResult);

--- a/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreak.cs
+++ b/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreak.cs
@@ -2,29 +2,34 @@ using System.Text.RegularExpressions;
 
 namespace ReplaceLineBreaksInAStringCSharp;
 
-public static class ReplaceLineBreak
+public static partial class ReplaceLineBreak
 {
-    public static string ReplaceLineBreaksUsingTheStringReplaceMethod()
-    {
-        const string text = "This is a line.\rThis is another line.";
-        var newText = text.Replace("\r\n", "\n").Replace("\r", "\n");
-        
-        return newText;
-    }
+    public const string Text = "Line one.\r\nLine two.\nLine three.\rLine four.";
 
-    public static string ReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod()
-    {
-        const string text = "This is a line.\rThis is another line.";
-        var newText = text.ReplaceLineEndings("\n");
-        
-        return newText;
-    }
+    public static string ReplaceLineBreaksUsingTheStringReplaceMethod() =>
+        ReplaceLineBreaksUsingTheStringReplaceMethod(Text);
 
-    public static string ReplaceLineBreaksUsingTheRegularExpressionReplaceMethod()
-    {
-        const string text = "This is a line.\rThis is another line.";
-        var newText = Regex.Replace(text, @"(\r\n|\r)", "\n");
-        
-        return newText;
-    }
+    public static string ReplaceLineBreaksUsingTheStringReplaceMethod(string text) =>
+        text.Replace("\r\n", "\n").Replace("\r", "\n");
+
+    public static string ReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod() =>
+        ReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod(Text);
+
+    public static string ReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod(string text) =>
+        text.ReplaceLineEndings("\n");
+
+    public static string ReplaceLineBreaksUsingTheRegularExpressionReplaceMethod() =>
+        ReplaceLineBreaksUsingTheRegularExpressionReplaceMethod(Text);
+
+    public static string ReplaceLineBreaksUsingTheRegularExpressionReplaceMethod(string text) =>
+        LineBreakRegex().Replace(text, "\n");
+
+    public static string RemoveLineBreaks() =>
+        RemoveLineBreaks(Text);
+
+    public static string RemoveLineBreaks(string text) =>
+        text.ReplaceLineEndings(string.Empty);
+
+    [GeneratedRegex(@"\r\n|\r|\n")]
+    private static partial Regex LineBreakRegex();
 }

--- a/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharp.csproj
+++ b/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharpBenchmarks/ReplaceLineBreakBenchmarks.cs
+++ b/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharpBenchmarks/ReplaceLineBreakBenchmarks.cs
@@ -4,14 +4,41 @@ using ReplaceLineBreaksInAStringCSharp;
 namespace ReplaceLineBreaksInAStringCSharpBenchmarks;
 
 [MemoryDiagnoser]
-public  class ReplaceLineBreakBenchmarks
+public class ReplaceLineBreakBenchmarks
 {
-    [Benchmark]
-    public string StringReplace() => ReplaceLineBreak.ReplaceLineBreaksUsingTheStringReplaceMethod();
+    private const string ShortText = "This is a line.\rThis is another line.";
+
+    private const string MixedText =
+        "The quick brown fox jumps over the lazy dog.\r\n" +
+        "Pack my box with five dozen liquor jugs.\n" +
+        "How vexingly quick daft zebras jump.\r" +
+        "Sphinx of black quartz, judge my vow.\r\n" +
+        "Jackdaws love my big sphinx of quartz.\n" +
+        "The five boxing wizards jump quickly.\r" +
+        "Bright vixens jump; dozy fowl quack.\r\n" +
+        "Quick zephyrs blow, vexing daft Jim.\n" +
+        "Two driven jocks help fax my big quiz.\r" +
+        "Waltz, bad nymph, for quick jigs vex.\r\n" +
+        "Glib jocks quiz nymph to vex dwarf.\n" +
+        "Fickle jinx bog dwarves spy math quiz.\r";
+
+    [Params("Short", "Mixed")]
+    public string Input { get; set; } = "Short";
+
+    private string _text = ShortText;
+
+    [GlobalSetup]
+    public void GlobalSetup() => _text = Input == "Short" ? ShortText : MixedText;
 
     [Benchmark]
-    public string StringReplaceLineEndings() => ReplaceLineBreak.ReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod();
+    public string StringReplace() =>
+        ReplaceLineBreak.ReplaceLineBreaksUsingTheStringReplaceMethod(_text);
 
     [Benchmark]
-    public string RegexReplace() => ReplaceLineBreak.ReplaceLineBreaksUsingTheRegularExpressionReplaceMethod();
+    public string StringReplaceLineEndings() =>
+        ReplaceLineBreak.ReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod(_text);
+
+    [Benchmark]
+    public string RegexReplace() =>
+        ReplaceLineBreak.ReplaceLineBreaksUsingTheRegularExpressionReplaceMethod(_text);
 }

--- a/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharpBenchmarks/ReplaceLineBreaksInAStringCSharpBenchmarks.csproj
+++ b/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharpBenchmarks/ReplaceLineBreaksInAStringCSharpBenchmarks.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharpTests/ReplaceLineBreakTests.cs
+++ b/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharpTests/ReplaceLineBreakTests.cs
@@ -4,10 +4,10 @@ namespace ReplaceLineBreaksInAStringCSharpTests;
 
 public class ReplaceLineBreakTests
 {
-    private const string Expected = "This is a line.\nThis is another line.";
-    
+    private const string Expected = "Line one.\nLine two.\nLine three.\nLine four.";
+
     [Fact]
-    public void WhenReplaceLineBreaksUsingTheStringReplaceMethod_ThenReturnStringOnOneLine()
+    public void WhenReplaceLineBreaksUsingTheStringReplaceMethod_ThenReturnStringWithUpdatedLineEndings()
     {
         var actual = ReplaceLineBreak.ReplaceLineBreaksUsingTheStringReplaceMethod();
 
@@ -15,7 +15,7 @@ public class ReplaceLineBreakTests
     }
 
     [Fact]
-    public void WhenReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod_ThenReturnStringWithUpdatedLineEnding()
+    public void WhenReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod_ThenReturnStringWithUpdatedLineEndings()
     {
         var actual = ReplaceLineBreak.ReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod();
 
@@ -23,10 +23,42 @@ public class ReplaceLineBreakTests
     }
 
     [Fact]
-    public void WhenReplaceLineBreaksUsingTheRegularExpressionReplaceMethod_ThenReturnStringWithUpdatedLineEnding()
+    public void WhenReplaceLineBreaksUsingTheRegularExpressionReplaceMethod_ThenReturnStringWithUpdatedLineEndings()
     {
         var actual = ReplaceLineBreak.ReplaceLineBreaksUsingTheRegularExpressionReplaceMethod();
 
         Assert.Equal(Expected, actual);
+    }
+
+    [Fact]
+    public void WhenRemoveLineBreaks_ThenReturnStringWithNoLineBreaksAtAll()
+    {
+        var actual = ReplaceLineBreak.RemoveLineBreaks();
+
+        Assert.Equal("Line one.Line two.Line three.Line four.", actual);
+    }
+
+    [Fact]
+    public void WhenReplacingCarriageReturnBeforeCarriageReturnLineFeed_ThenWindowsLineBreakDoubles()
+    {
+        const string text = "Line one.\r\nLine two.";
+
+        var wrongOrder = text.Replace("\r", "\n");
+        var rightOrder = text.Replace("\r\n", "\n").Replace("\r", "\n");
+
+        Assert.Equal("Line one.\n\nLine two.", wrongOrder);
+        Assert.Equal("Line one.\nLine two.", rightOrder);
+    }
+
+    [Fact]
+    public void WhenTextContainsALineSeparator_ThenOnlyReplaceLineEndingsMatchesIt()
+    {
+        const string text = "Line one.\u2028Line two.";
+
+        var replaceLineEndings = ReplaceLineBreak.ReplaceLineBreaksUsingTheStringReplaceLineEndingsMethod(text);
+        var replaceChain = ReplaceLineBreak.ReplaceLineBreaksUsingTheStringReplaceMethod(text);
+
+        Assert.Equal("Line one.\nLine two.", replaceLineEndings);
+        Assert.Equal(text, replaceChain);
     }
 }

--- a/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharpTests/ReplaceLineBreaksInAStringCSharpTests.csproj
+++ b/strings-csharp/ReplaceLineBreaksInAStringCSharp/ReplaceLineBreaksInAStringCSharpTests/ReplaceLineBreaksInAStringCSharpTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -10,13 +10,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
Sample update for the republished article **Replace Line Breaks in a String in C#: ReplaceLineEndings**.

### What changes

- **All three projects retargeted `net7.0` -> `net10.0`** (app, tests, benchmarks). `net7.0` was the only version string in the sample and it is out of support.
- **The regex was wrong.** `@"(\r\n|\r)"` never names `\n`, so the sample silently ignored Unix line endings, which is the most common kind of text a .NET application reads today. Fixed to `\r\n|\r|\n`, and the capturing group dropped because nothing captures. Converted to a `[GeneratedRegex]` partial method: the current idiom, and it also takes the static-cache lookup out of the benchmarked path.
- **The fixture could not demonstrate the article's subject.** Every method ran against `"This is a line.\rThis is another line."`, one carriage return, no `\r\n` and no `\n`. It is now `"Line one.\r\nLine two.\nLine three.\rLine four."`, which carries all three common sequences and makes the CRLF ordering trap visible. Each method gains a `string`-taking overload so the benchmark can drive two inputs; the parameterless ones keep the fixture.
- **New `RemoveLineBreaks()`**, via `ReplaceLineEndings("")`, backing the article's new removal section.
- **Tests: 3 expectations updated, 3 cases added.** The new ones cover the removal method, the ordering trap (replacing `\r` before `\r\n` doubles every Windows break), and a U+2028 line separator that `ReplaceLineEndings()` matches and the `Replace()` chain does not.
- **Benchmarks: a second input**, a paragraph mixing `\r\n`, `\n` and `\r`, with the old short string kept as a labelled case.
- **Packages:** BenchmarkDotNet 0.15.8, Microsoft.NET.Test.Sdk 18.9.0, xunit 2.9.3, xunit.runner.visualstudio 4.0.0, coverlet.collector 10.0.1.

### Verification

`dotnet build -c Release` clean, 0 warnings. `dotnet test -c Release` **6/6 passing** on .NET 10.0.10.

Benchmark re-run on .NET 10.0.10, X64 RyuJIT:

```
| Method                   | Input | Mean      | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|------------------------- |------ |----------:|---------:|---------:|-------:|-------:|----------:|
| StringReplace            | Mixed | 213.71 ns | 4.150 ns | 4.613 ns | 0.2275 | 0.0002 |    1904 B |
| StringReplaceLineEndings | Mixed | 202.75 ns | 2.508 ns | 2.094 ns | 0.1137 |      - |     952 B |
| RegexReplace             | Mixed | 486.05 ns | 6.806 ns | 6.034 ns | 0.1135 |      - |     952 B |
| StringReplace            | Short |  33.16 ns | 0.717 ns | 1.158 ns | 0.0114 |      - |      96 B |
| StringReplaceLineEndings | Short |  32.69 ns | 0.411 ns | 0.384 ns | 0.0114 |      - |      96 B |
| RegexReplace             | Short |  98.23 ns | 0.892 ns | 0.745 ns | 0.0114 |      - |      96 B |
```

The article's published 2023 figures (`Replace()` 24.69 ns, `ReplaceLineEndings()` 79.84 ns, `Regex.Replace()` 201.44 ns) do not survive. On .NET 10 the first two are a tie on both inputs, swapping places between runs; `String.Replace()` allocates twice as much on mixed text because it makes two passes; `Regex.Replace()` is the slowest by a wide margin either way.
