### PR TITLE
Multipart form-data with HttpClient: retarget net10.0, modernise the test server, cover JsonContent

### DIFF
--- a/aspnetcore-features/UsingMultipartFormDataInHttpClient/TestServer/Controllers/TestController.cs
+++ b/aspnetcore-features/UsingMultipartFormDataInHttpClient/TestServer/Controllers/TestController.cs
@@ -1,35 +1,34 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Mime;
 
-namespace TestServer1.Controllers
+namespace TestServer.Controllers;
+
+[ApiController]
+public class TestController : ControllerBase
 {
-    [ApiController]
-    public class TestController : ControllerBase
+    [HttpPost("upload-form")]
+    public IActionResult Post()
     {
-        [HttpPost("upload-form")]
-        public IActionResult Post()
+        if (Request.Form.ContainsKey("first_name") &&
+            Request.Form.ContainsKey("last_name"))
         {
-            if (Request.Form.ContainsKey("first_name") &&
-                Request.Form.ContainsKey("last_name"))
-            {
-                return Ok();
-            }
-
-            return BadRequest();
+            return Ok();
         }
 
-        [HttpPost("upload-image")]
-        public IActionResult PostFile()
+        return BadRequest();
+    }
+
+    [HttpPost("upload-image")]
+    public IActionResult PostFile()
+    {
+        var files = Request.Form.Files;
+        if (files.Count == 1 &&
+            files.First().FileName == "john_doe.jpg" &&
+            files.First().ContentType == MediaTypeNames.Image.Jpeg)
         {
-            var files = Request.Form.Files;
-            if (files.Count == 1 &&
-                files.First().FileName == "john_doe.jpg" &&
-                files.First().ContentType == MediaTypeNames.Image.Jpeg)
-            {
-                return Ok();
-            }
-            
-            return BadRequest();
+            return Ok();
         }
+
+        return BadRequest();
     }
 }

--- a/aspnetcore-features/UsingMultipartFormDataInHttpClient/TestServer/Program.cs
+++ b/aspnetcore-features/UsingMultipartFormDataInHttpClient/TestServer/Program.cs
@@ -1,19 +1,17 @@
-public class Program
-{
-    private static void Main(string[] args)
-    {
-        var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(args);
 
-        // Add services to the container.
+// Add services to the container.
 
-        builder.Services.AddControllers();
+builder.Services.AddControllers();
 
-        var app = builder.Build();
+var app = builder.Build();
 
-        // Configure the HTTP request pipeline.
+// Configure the HTTP request pipeline.
 
-        app.MapControllers();
+app.MapControllers();
 
-        app.Run();
-    }
-}
+app.Run();
+
+// WebApplicationFactory<Program> in the test project needs Program to be a nameable,
+// accessible type. Top-level statements generate an internal one, so we declare it here.
+public partial class Program;

--- a/aspnetcore-features/UsingMultipartFormDataInHttpClient/TestServer/TestServer.csproj
+++ b/aspnetcore-features/UsingMultipartFormDataInHttpClient/TestServer/TestServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/aspnetcore-features/UsingMultipartFormDataInHttpClient/Tests/MultipartFormDataTests.cs
+++ b/aspnetcore-features/UsingMultipartFormDataInHttpClient/Tests/MultipartFormDataTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Net.Mime;
 using System.Text;
 
@@ -23,10 +24,8 @@ namespace Tests
             multipartContent.Add(new StringContent("Doe", Encoding.UTF8, MediaTypeNames.Text.Plain), "last_name");
 
             using var response = await _httpClient.PostAsync("http://localhost:5272/upload-form", multipartContent);
-            if (!response.IsSuccessStatusCode)
-            {
-                Assert.Fail("Request has returned an error status.");
-            }
+
+            response.EnsureSuccessStatusCode();
         }
 
         [Fact]
@@ -34,16 +33,14 @@ namespace Tests
         {
             using MultipartFormDataContent multipartContent = new();
 
-            var imageContent = new StreamContent(File.OpenRead($".{Path.DirectorySeparatorChar}john_doe.jpg"));
+            var imageContent = new StreamContent(File.OpenRead("john_doe.jpg"));
             imageContent.Headers.ContentType = MediaTypeHeaderValue.Parse(MediaTypeNames.Image.Jpeg);
 
             multipartContent.Add(imageContent, "profile_picture", "john_doe.jpg");
 
             using var response = await _httpClient.PostAsync("http://localhost:5272/upload-image", multipartContent);
-            if (!response.IsSuccessStatusCode)
-            {
-                Assert.Fail("Request has returned an error status.");
-            }
+
+            response.EnsureSuccessStatusCode();
         }
 
         [Fact]
@@ -51,16 +48,32 @@ namespace Tests
         {
             using MultipartFormDataContent multipartContent = new();
 
-            var byteArrayContent = new ByteArrayContent(await File.ReadAllBytesAsync($".{Path.DirectorySeparatorChar}john_doe.jpg"));
+            var byteArrayContent = new ByteArrayContent(await File.ReadAllBytesAsync("john_doe.jpg"));
             byteArrayContent.Headers.ContentType = MediaTypeHeaderValue.Parse(MediaTypeNames.Image.Jpeg);
 
             multipartContent.Add(byteArrayContent, "profile_picture", "john_doe.jpg");
 
             using var response = await _httpClient.PostAsync("http://localhost:5272/upload-image", multipartContent);
-            if (!response.IsSuccessStatusCode)
-            {
-                Assert.Fail("Request has returned an error status.");
-            }
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        [Fact]
+        public async Task WhenSendingJsonPartInMultipartRequest_ThenPartCarriesJsonContentType()
+        {
+            using MultipartFormDataContent multipartContent = new();
+
+            var jsonContent = JsonContent.Create(new { City = "Belgrade", Country = "Serbia" });
+
+            multipartContent.Add(new StringContent("John", Encoding.UTF8, MediaTypeNames.Text.Plain), "first_name");
+            multipartContent.Add(new StringContent("Doe", Encoding.UTF8, MediaTypeNames.Text.Plain), "last_name");
+            multipartContent.Add(jsonContent, "address");
+
+            Assert.Equal("application/json; charset=utf-8", jsonContent.Headers.ContentType?.ToString());
+
+            using var response = await _httpClient.PostAsync("http://localhost:5272/upload-form", multipartContent);
+
+            response.EnsureSuccessStatusCode();
         }
     }
 }

--- a/aspnetcore-features/UsingMultipartFormDataInHttpClient/Tests/Tests.csproj
+++ b/aspnetcore-features/UsingMultipartFormDataInHttpClient/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Sample refresh for https://code-maze.com/aspnetcore-multipart-form-data-in-httpclient/

- Both projects retargeted `net7.0` -> `net10.0`.
- Tests packages lifted: `Microsoft.AspNetCore.Mvc.Testing` 10.0.11, `Microsoft.NET.Test.Sdk` 18.9.0, `xunit` 2.9.3, `xunit.runner.visualstudio` 4.0.0, `coverlet.collector` 10.0.1.
- `TestServer/Program.cs` rewritten from an explicit `Program` class with a `private static Main` to top-level statements, plus a `public partial class Program;` declaration so `WebApplicationFactory<Program>` still has a nameable type.
- Controller namespace `TestServer1.Controllers` corrected to a file-scoped `TestServer.Controllers`.
- The three manual `if (!response.IsSuccessStatusCode) Assert.Fail(...)` blocks replaced with `response.EnsureSuccessStatusCode()`.
- `$".{Path.DirectorySeparatorChar}john_doe.jpg"` simplified to `"john_doe.jpg"`; the csproj already copies the file to the output directory.
- New test covering a `JsonContent` part, so every `HttpContent` subclass the article's new lookup table names is exercised.

`dotnet test` locally: 4 of 4 passed on SDK 10.0.302.