### PR TITLE
HashSet in C#: retarget net10.0, fix IsOdd for negatives, seed Random, correct assertions

### DIFF
--- a/collections-csharp/HashSetInCSharp/HashSetInCSharp/HashSetInCSharp.csproj
+++ b/collections-csharp/HashSetInCSharp/HashSetInCSharp/HashSetInCSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/collections-csharp/HashSetInCSharp/HashSetInCSharp/HashSetsInCSharpMethods.cs
+++ b/collections-csharp/HashSetInCSharp/HashSetInCSharp/HashSetsInCSharpMethods.cs
@@ -45,9 +45,23 @@
             return list;
         }
 
-        public HashSet<int> RandomInts(int size) 
+        public HashSet<string> CreateFromList(List<string> languageList)
         {
-            var rand = new Random();
+            var fromList = languageList.ToHashSet();
+
+            return fromList;
+        }
+
+        public HashSet<string> CreateCaseInsensitive(List<string> languageList)
+        {
+            var caseInsensitive = new HashSet<string>(languageList, StringComparer.OrdinalIgnoreCase);
+
+            return caseInsensitive;
+        }
+
+        public HashSet<int> RandomInts(int size, int seed = 42)
+        {
+            var rand = new Random(seed);
             var numbers = new HashSet<int>();
 
             for (int i = 0; i < size; i++) 
@@ -60,7 +74,7 @@
 
         public bool IsOdd(int num) 
         {
-            return num % 2 == 1;
+            return num % 2 != 0;
         }
     }
 }

--- a/collections-csharp/HashSetInCSharp/HashSetInCSharpTests/HashSetInCSharpTests.csproj
+++ b/collections-csharp/HashSetInCSharp/HashSetInCSharpTests/HashSetInCSharpTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,10 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/collections-csharp/HashSetInCSharp/HashSetInCSharpTests/HashSetInCSharpUnitTests.cs
+++ b/collections-csharp/HashSetInCSharp/HashSetInCSharpTests/HashSetInCSharpUnitTests.cs
@@ -5,19 +5,19 @@ namespace HashSetInCSharpTests
     [TestClass]
     public class HashSetInCSharpUnitTests
     {
-        HashSetsInCSharpMethods hashSet = new HashSetsInCSharpMethods();
-        private readonly  HashSet<string> _languages;
+        private readonly HashSetsInCSharpMethods _methods = new HashSetsInCSharpMethods();
+        private readonly HashSet<string> _languages;
 
         public HashSetInCSharpUnitTests()
         {
-            _languages = hashSet.ProgrammingLanguages();
+            _languages = _methods.ProgrammingLanguages();
         }
 
         [TestMethod]
         public void GivenAHashSet_WhenNotEmpty_VerifyCountAndContains()
         {
             Assert.IsInstanceOfType(_languages, typeof(HashSet<string>));
-            Assert.AreEqual(_languages.Count(), 9);
+            Assert.AreEqual(9, _languages.Count);
             Assert.IsTrue(_languages.Contains("C#"));
         }
 
@@ -27,9 +27,9 @@ namespace HashSetInCSharpTests
             _languages.Add("C");
             _languages.Add("C++");
             _languages.Add("C#");
-           
+
             Assert.IsInstanceOfType(_languages, typeof(HashSet<string>));
-            Assert.AreEqual(_languages.Count(), 9);
+            Assert.AreEqual(9, _languages.Count);
         }
 
         [TestMethod]
@@ -37,33 +37,33 @@ namespace HashSetInCSharpTests
         {
             var elementToRemove = "Java";
 
-            var updatedLanguages = hashSet.RemoveElement(_languages, elementToRemove);
+            var updatedLanguages = _methods.RemoveElement(_languages, elementToRemove);
 
             Assert.IsFalse(updatedLanguages.Contains(elementToRemove));
-            Assert.AreEqual(_languages.Count(), 8);
+            Assert.AreEqual(8, _languages.Count);
         }
 
         [TestMethod]
         public void GivenAHashSet_WhenNotEmpty_VerifyNoOddElements()
         {
-            var numbers = hashSet.RandomInts(100);
+            var numbers = _methods.RandomInts(100);
             var oddNumbers = new HashSet<int>();
 
-            foreach (var item in numbers) 
+            foreach (var item in numbers)
             {
-                if (hashSet.IsOdd(item) == true) 
+                if (_methods.IsOdd(item) == true)
                 {
                     oddNumbers.Add(item);
                 }
             }
 
-            hashSet.RemoveWhereElement(numbers);
+            _methods.RemoveWhereElement(numbers);
             var testValue = oddNumbers.First();
-            var checkValue = hashSet.IsOdd(testValue);
-            
+            var checkValue = _methods.IsOdd(testValue);
+
             Assert.IsTrue(checkValue);
             Assert.IsFalse(oddNumbers.IsSubsetOf(numbers));
-            Assert.AreEqual(numbers.Union(oddNumbers).Count(), 100);
+            Assert.AreEqual(100, numbers.Union(oddNumbers).Count());
         }
 
         [TestMethod]
@@ -71,19 +71,48 @@ namespace HashSetInCSharpTests
         {
             _languages.Clear();
 
-            Assert.AreEqual(0, _languages.Count());
+            Assert.AreEqual(0, _languages.Count);
             Assert.IsNull(_languages.FirstOrDefault());
         }
 
         [TestMethod]
         public void GivenAHashSet_WhenNotEmpty_VerifyListPopulated()
         {
-            var numbers = hashSet.RandomInts(100);
+            var numbers = _methods.RandomInts(100);
 
-            var numbersList = hashSet.CreateList(numbers);
+            var numbersList = _methods.CreateList(numbers);
 
             CollectionAssert.AllItemsAreInstancesOfType(numbersList, typeof(int));
-            Assert.AreEqual(numbersList.Count(), numbers.Count());
+            Assert.AreEqual(numbers.Count, numbersList.Count);
+        }
+
+        [TestMethod]
+        public void GivenAList_WhenConvertedWithToHashSet_ThenDuplicatesAreDropped()
+        {
+            var languageList = new List<string> { "C#", "F#", "C#", "VB" };
+
+            var fromList = _methods.CreateFromList(languageList);
+
+            Assert.AreEqual(3, fromList.Count);
+            Assert.IsTrue(fromList.Contains("C#"));
+        }
+
+        [TestMethod]
+        public void GivenAList_WhenBuiltWithAnOrdinalIgnoreCaseComparer_ThenCasingDoesNotCreateDuplicates()
+        {
+            var languageList = new List<string> { "C#", "c#", "F#" };
+
+            var caseInsensitive = _methods.CreateCaseInsensitive(languageList);
+
+            Assert.AreEqual(2, caseInsensitive.Count);
+            Assert.IsTrue(caseInsensitive.Contains("c#"));
+        }
+
+        [TestMethod]
+        public void GivenANegativeNumber_WhenOdd_VerifyIsOddIsTrue()
+        {
+            Assert.IsTrue(_methods.IsOdd(-3));
+            Assert.IsFalse(_methods.IsOdd(-4));
         }
 
         [TestMethod]
@@ -103,7 +132,7 @@ namespace HashSetInCSharpTests
             var moreLanguages = new HashSet<string> { "Assembly", "Pascal", "HTML", "CSS", "PHP" };
 
             _languages.UnionWith(moreLanguages);
-            Assert.AreEqual(_languages.Count(), 14);
+            Assert.AreEqual(14, _languages.Count);
         }
 
         [TestMethod]
@@ -113,7 +142,7 @@ namespace HashSetInCSharpTests
 
             _languages.IntersectWith(moreLanguages);
 
-            Assert.AreEqual(_languages.Count(), 5);
+            Assert.AreEqual(5, _languages.Count);
             Assert.IsTrue(_languages.Contains("C"));
             Assert.IsTrue(_languages.Contains("C++"));
             Assert.IsTrue(_languages.Contains("C#"));
@@ -129,7 +158,7 @@ namespace HashSetInCSharpTests
 
             _languages.ExceptWith(moreLanguages);
 
-            Assert.AreEqual(_languages.Count(), 4);
+            Assert.AreEqual(4, _languages.Count);
             Assert.IsTrue(_languages.Contains("TypeScript"));
             Assert.IsTrue(_languages.Contains("Python"));
             Assert.IsTrue(_languages.Contains("JavaScript"));
@@ -143,8 +172,8 @@ namespace HashSetInCSharpTests
             var moreLanguages = new HashSet<string> { "Assembly", "Pascal", "HTML", "CSS", "PHP" };
 
             _languages.SymmetricExceptWith(moreLanguages);
-            
-            Assert.AreEqual(_languages.Count(), 14);
+
+            Assert.AreEqual(14, _languages.Count);
         }
 
         [TestMethod]


### PR DESCRIPTION
Retargets `collections-csharp/HashSetInCSharp` to `net10.0` and fixes four defects the accompanying article rewrite exposed.

**Retarget and packages**
- `HashSetInCSharp.csproj` and `HashSetInCSharpTests.csproj`: `net6.0` -> `net10.0`.
- `Microsoft.NET.Test.Sdk` 17.1.0 -> 18.9.0, `coverlet.collector` 3.1.2 -> 10.0.1, and `MSTest.TestAdapter` / `MSTest.TestFramework` 2.2.8 replaced by the `MSTest` 4.3.3 meta-package.

**Fixes**
- `IsOdd()` returned `false` for negative odd numbers: `-3 % 2` is `-1` in C#, so `num % 2 == 1` is false. Now `num % 2 != 0`, with a test covering negative input.
- `RandomInts()` built its data from an unseeded `Random`, and `GivenAHashSet_WhenNotEmpty_VerifyNoOddElements` then called `First()` on a set that could in principle be empty. The generator is seeded (`RandomInts(int size, int seed = 42)`), so the test is repeatable in CI.
- `Assert.AreEqual` takes `(expected, actual)`. The tests passed the actual value first in every count assertion, so a failure reported the two the wrong way round. Swapped throughout.
- `Count()` is the LINQ extension on `IEnumerable<T>`; `HashSet<T>` exposes `Count` as a property. The tests now read the property.
- The `HashSetsInCSharpMethods` field was named `hashSet`, which is not a `HashSet`. Renamed to `_methods` and made `private readonly`.

**Additions**
- `CreateFromList()` (`ToHashSet()`) and `CreateCaseInsensitive()` (the `IEnumerable<T>` plus `IEqualityComparer<T>` constructor overload), each with a test, so the two new article snippets have a repo home.

Build clean on SDK 10.0.302: 0 warnings, 0 errors. 15 tests pass.
